### PR TITLE
265-wrong-direction-for-n-output-gates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [{name = "Naja Authors", email = "contact@keplertech.io"}]
 readme = "src/najaeda/README.rst"
 requires-python = ">=3.8"
 license = {text = "Apache License 2.0"}
-version = "0.1.25"
+version = "0.2.0"
 
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/core/NajaVersion.h.in
+++ b/src/core/NajaVersion.h.in
@@ -7,8 +7,8 @@ namespace naja {
 #include <string>
 
 const std::string NAJA_MAJOR { "0" };
-const std::string NAJA_MINOR { "1" };
-const std::string NAJA_PATCH { "25" };
+const std::string NAJA_MINOR { "2" };
+const std::string NAJA_PATCH { "0" };
 const std::string NAJA_VERSION { NAJA_MAJOR + "." + NAJA_MINOR + "." + NAJA_PATCH };
 
 const std::string NAJA_GIT_HASH { "@NAJA_GIT_HASH@" };

--- a/src/najaeda/najaeda/netlist.py
+++ b/src/najaeda/najaeda/netlist.py
@@ -475,16 +475,18 @@ class Term:
     def __str__(self):
         term_str = ""
         path = get_snl_path_from_id_list(self.pathIDs)
+        snl_term = get_snl_term_for_ids(self.pathIDs, self.termIDs)
+        snl_term_str = snl_term.getName()
+        if snl_term.isUnnamed():
+            snl_term_str = "<unnamed>"
         if path.size() == 0:
-            term_str = get_snl_term_for_ids(self.pathIDs, self.termIDs).getName()
+            term_str = snl_term_str
         else:
-            term_str = (
-                f"{path}/{get_snl_term_for_ids(self.pathIDs, self.termIDs).getName()}"
-            )
+            term_str = f"{path}/{snl_term_str}"
         if self.is_bus():
             term_str += f"[{self.get_msb()}:{self.get_lsb()}]"
         elif self.is_bus_bit():
-            term_str += f"[{self.get_lsb()}]"
+            term_str += f"[{self.get_msb()}]"
         return term_str
 
     def __repr__(self) -> str:
@@ -885,7 +887,7 @@ class Instance:
         the wire a to the output of the assign and b to the input.
 
         :return: True if this is an assign. Assigns are represented with
-        anonymous Assign instances.
+        unnamed Assign instances.
         :rtype: bool
         """
         return self.__get_snl_model().isAssign()

--- a/src/nl/formats/verilog/backend/SNLVRLDumper.cpp
+++ b/src/nl/formats/verilog/backend/SNLVRLDumper.cpp
@@ -252,7 +252,7 @@ NLName SNLVRLDumper::createNetName(const SNLNet* net, DesignInsideAnonymousNamin
 }
 
 NLName SNLVRLDumper::getNetName(const SNLNet* net, const DesignInsideAnonymousNaming& naming) {
-  if (net->isAnonymous()) {
+  if (net->isUnnamed()) {
     auto it = naming.netNames_.find(net->getID());
     assert(it != naming.netNames_.end());
     return it->second;
@@ -314,7 +314,7 @@ bool SNLVRLDumper::dumpNet(const SNLNet* net, std::ostream& o, DesignInsideAnony
     return false;
   }
   NLName netName;
-  if (net->isAnonymous()) {
+  if (net->isUnnamed()) {
     netName = createNetName(net, naming);
   } else {
     netName = net->getName();
@@ -332,7 +332,7 @@ bool SNLVRLDumper::dumpNet(const SNLNet* net, std::ostream& o, DesignInsideAnony
 void SNLVRLDumper::dumpNets(const SNLDesign* design, std::ostream& o, DesignInsideAnonymousNaming& naming) {
   bool atLeastOne = false;
   for (auto net: design->getNets()) {
-    if (not net->isAnonymous()) {
+    if (not net->isUnnamed()) {
       auto name = net->getName();
       if (design->getTerm(name)) {
         //already dumped
@@ -534,7 +534,7 @@ bool SNLVRLDumper::dumpInstance(
   if (NLDB0::isGate(instance->getModel())) {
     auto gateName = NLDB0::getGateName(instance->getModel());
     o << gateName << " ";
-    if (not instance->isAnonymous()) {
+    if (not instance->isUnnamed()) {
       o << instance->getName().getString();
     }
     o << "(";
@@ -580,14 +580,14 @@ bool SNLVRLDumper::dumpInstance(
     }
   }
   std::string instanceName;
-  if (instance->isAnonymous()) {
+  if (instance->isUnnamed()) {
     instanceName = createInstanceName(instance, naming);
   } else {
     instanceName = instance->getName().getString();
   }
   dumpAttributes(instance, o);
   auto model = instance->getModel();
-  if (not model->isAnonymous()) { //FIXME !!
+  if (not model->isUnnamed()) { //FIXME !!
     o << dumpName(model->getName().getString()) << " ";
   }
   dumpInstParameters(instance, o);
@@ -765,16 +765,16 @@ void SNLVRLDumper::dumpParameters(const SNLDesign* design, std::ostream& o) {
 void SNLVRLDumper::dumpOneDesign(const SNLDesign* design, std::ostream& o) {
   DesignInsideAnonymousNaming naming;
   for (auto term: design->getTerms()) {
-    if (not term->isAnonymous()) {
+    if (not term->isUnnamed()) {
       naming.netTermNameSet_.insert(term->getName());
     }
   }
   for (auto net: design->getNets()) {
-    if (not net->isAnonymous()) {
+    if (not net->isUnnamed()) {
       naming.netTermNameSet_.insert(net->getName());
     }
   }
-  if (design->isAnonymous()) {
+  if (design->isUnnamed()) {
     createDesignName(design);
   }
   dumpAttributes(design, o);
@@ -823,7 +823,7 @@ std::string SNLVRLDumper::getTopFileName(const SNLDesign* top) const {
   if (configuration_.hasTopFileName()) {
     return configuration_.getTopFileName();
   }
-  if (not top->isAnonymous()) {
+  if (not top->isUnnamed()) {
     return top->getName().getString() + ".v";
   }
   return "top.v";
@@ -833,7 +833,7 @@ std::string SNLVRLDumper::getLibraryFileName(const NLLibrary* library) const {
   if (configuration_.hasLibraryFileName()) {
     return configuration_.getLibraryFileName();
   }
-  if (not library->isAnonymous()) {
+  if (not library->isUnnamed()) {
     return library->getName().getString() + ".v";
   }
   return "library.v";
@@ -842,7 +842,7 @@ std::string SNLVRLDumper::getLibraryFileName(const NLLibrary* library) const {
 void SNLVRLDumper::dumpDesign(const SNLDesign* design, const std::filesystem::path& path) {
   if (not std::filesystem::exists(path)) {
     std::ostringstream reason;
-    if (not design->isAnonymous()) {
+    if (not design->isUnnamed()) {
       reason << design->getName().getString();
     } else {
       reason << "anonymous design";
@@ -889,7 +889,7 @@ void SNLVRLDumper::dumpDesign(const SNLDesign* design, const std::filesystem::pa
 void SNLVRLDumper::dumpLibrary(const NLLibrary* library, const std::filesystem::path& path) {
   if (not std::filesystem::exists(path)) {
     std::ostringstream reason;
-    if (not library->isAnonymous()) {
+    if (not library->isUnnamed()) {
       reason << library->getName().getString();
     } else {
       reason << library->getDescription();

--- a/src/nl/nl/nl/NLDB0.cpp
+++ b/src/nl/nl/nl/NLDB0.cpp
@@ -200,8 +200,8 @@ SNLDesign* NLDB0::getOrCreateNOutputGate(const GateType& type, size_t nbOutputs)
   auto gate = gateLibrary->getSNLDesign(NLName(gateName));
   if (not gate) {
     gate = SNLDesign::create(gateLibrary, SNLDesign::Type::Primitive, NLName(gateName));
-    SNLScalarTerm::create(gate, SNLTerm::Direction::Input);
     SNLBusTerm::create(gate, SNLTerm::Direction::Output, NLID::Bit(nbOutputs-1), 0);
+    SNLScalarTerm::create(gate, SNLTerm::Direction::Input);
   }
   return gate;
 }
@@ -273,15 +273,19 @@ bool NLDB0::isGate(const SNLDesign* design) {
 }
 
 SNLScalarTerm* NLDB0::getGateSingleTerm(const SNLDesign* gate) {
-  if (isGate(gate)) {
+  if (isNInputGate(gate)) {
     return gate->getScalarTerm(NLID::DesignObjectID(0));
+  } else if (isNOutputGate(gate)) {
+    return gate->getScalarTerm(NLID::DesignObjectID(1));
   }
   return nullptr;
 }
 
 SNLBusTerm* NLDB0::getGateNTerms(const SNLDesign* gate) {
-  if (isGate(gate)) {
+  if (isNInputGate(gate)) {
     return gate->getBusTerm(NLID::DesignObjectID(1));
+  } else if (isNOutputGate(gate)) {
+    return gate->getBusTerm(NLID::DesignObjectID(0));
   }
   return nullptr;
 }

--- a/src/nl/nl/nl/NLLibrary.cpp
+++ b/src/nl/nl/nl/NLLibrary.cpp
@@ -313,13 +313,13 @@ NajaCollection<PNLDesign*> NLLibrary::getPNLDesigns() const {
 
 void NLLibrary::addLibrary(NLLibrary* library) {
   libraries_.insert(*library);
-  if (not library->isAnonymous()) {
+  if (not library->isUnnamed()) {
     libraryNameIDMap_[library->getName()] = library->id_;
   }
 }
 
 void NLLibrary::removeLibrary(NLLibrary* library) {
-  if (not library->isAnonymous()) {
+  if (not library->isUnnamed()) {
     libraryNameIDMap_.erase(library->getName());
   }
   libraries_.erase(*library);
@@ -339,13 +339,13 @@ void NLLibrary::addSNLDesignAndSetID(SNLDesign* design) {
 
 void NLLibrary::addSNLDesign(SNLDesign* design) {
   snlDesigns_.insert(*design);
-  if (not design->isAnonymous()) {
+  if (not design->isUnnamed()) {
     designNameIDMap_[design->getName()] = design->id_;
   }
 }
 
 void NLLibrary::removeSNLDesign(SNLDesign* design) {
-  if (not design->isAnonymous()) {
+  if (not design->isUnnamed()) {
     designNameIDMap_.erase(design->getName());
   }
   snlDesigns_.erase(*design);
@@ -365,13 +365,13 @@ void NLLibrary::addPNLDesignAndSetID(PNLDesign* design) {
 
 void NLLibrary::addPNLDesign(PNLDesign* design) {
   pnlDesigns_.insert(*design);
-  if (not design->isAnonymous()) {
+  if (not design->isUnnamed()) {
     pnlDesignNameIDMap_[design->getName()] = design->id_;
   }
 }
 
 void NLLibrary::removePNLDesign(PNLDesign* design) {
-  if (not design->isAnonymous()) {
+  if (not design->isUnnamed()) {
     pnlDesignNameIDMap_.erase(design->getName());
   }
   pnlDesigns_.erase(*design);
@@ -444,7 +444,7 @@ std::string NLLibrary::getString() const {
 std::string NLLibrary::getDescription() const {
   std::ostringstream description;
   description << "<" + std::string(getTypeName());
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     description << " " + name_.getString();
   }
   if (isPrimitives()) {

--- a/src/nl/nl/nl/NLLibrary.h
+++ b/src/nl/nl/nl/NLLibrary.h
@@ -127,8 +127,8 @@ class NLLibrary final: public NLObject {
     NLID getNLID() const;
     /// \return the name of this NLLibrary.
     NLName getName() const { return name_; }
-    /// \return true if this NLLibrary is anonymous, false otherwise.
-    bool isAnonymous() const { return name_.empty(); }
+    /// \return true if this NLLibrary is unnamed, false otherwise.
+    bool isUnnamed() const { return name_.empty(); }
     const char* getTypeName() const override;
     std::string getString() const override;
     std::string getDescription() const override;

--- a/src/nl/nl/nl/NLObject.h
+++ b/src/nl/nl/nl/NLObject.h
@@ -13,7 +13,7 @@
 namespace naja { namespace NL {
 
 /**
- * \brief SNLObject is the root object of SNL database objects.
+ * \brief NLObject is the root object of Naja database objects.
  */
 class NLObject: public NajaObject {
   public:

--- a/src/nl/nl/pnl/PNLDesign.cpp
+++ b/src/nl/nl/pnl/PNLDesign.cpp
@@ -309,10 +309,10 @@ const char* PNLDesign::getTypeName() const {
 
 // LCOV_EXCL_START
 std::string PNLDesign::getString() const {
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     return getName().getString();
   } else {
-    return "<anonymous>";
+    return "<unnamed>";
   }
 }
 // LCOV_EXCL_STOP
@@ -321,11 +321,11 @@ std::string PNLDesign::getString() const {
 std::string PNLDesign::getDescription() const {
   std::ostringstream stream;
   stream << "<" + std::string(getTypeName());
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     stream << " " + getName().getString();
   }
   stream << " " << getID();
-  if (not getLibrary()->isAnonymous()) {
+  if (not getLibrary()->isUnnamed()) {
     stream << " " << getLibrary()->getName().getString();
   }
   stream << " " << getLibrary()->getID();

--- a/src/nl/nl/pnl/PNLDesign.h
+++ b/src/nl/nl/pnl/PNLDesign.h
@@ -106,8 +106,8 @@ class PNLDesign final: public NLObject {
     /// \return NLName of this PNLDesign. 
     NLName getName() const { return name_; }
     void setName(const NLName& name);
-    /// \return true if this PNLDesign is anonymous.
-    bool isAnonymous() const { return name_.empty(); }
+    /// \return true if this PNLDesign is unnamed.
+    bool isUnnamed() const { return name_.empty(); }
 
     const char* getTypeName() const override;
     std::string getString() const override;

--- a/src/nl/nl/pnl/PNLDesignObject.h
+++ b/src/nl/nl/pnl/PNLDesignObject.h
@@ -33,7 +33,7 @@ class PNLDesignObject: public NL::NLObject {
   
   naja::NL::NLDB* getDB() const;
 
-  virtual bool isAnonymous() const = 0;
+  virtual bool isUnnamed() const = 0;
 
   protected:
     PNLDesignObject() = default;

--- a/src/nl/nl/pnl/PNLInstTerm.cpp
+++ b/src/nl/nl/pnl/PNLInstTerm.cpp
@@ -105,8 +105,8 @@ void PNLInstTerm::debugDump(size_t indent, bool recursive, std::ostream& stream)
 }
 //LCOV_EXCL_STOP
 
-bool PNLInstTerm::isAnonymous() const {
-  return getBitTerm()->isAnonymous();
+bool PNLInstTerm::isUnnamed() const {
+  return getBitTerm()->isUnnamed();
 }
 
 NLName PNLInstTerm::getName() const {

--- a/src/nl/nl/pnl/PNLInstTerm.h
+++ b/src/nl/nl/pnl/PNLInstTerm.h
@@ -38,7 +38,7 @@ class PNLInstTerm final: public PNLNetComponent {
 
     void destroy() override;
 
-    bool isAnonymous() const override;
+    bool isUnnamed() const override;
     NLName getName() const override;
 
   private:

--- a/src/nl/nl/pnl/PNLInstance.h
+++ b/src/nl/nl/pnl/PNLInstance.h
@@ -42,7 +42,7 @@ class PNLInstance final: public PNLDesignObject {
     PNLInstTerm* getInstTerm(const PNLBitTerm* term) const;
     PNLInstTerm* getInstTerm(const NLID::DesignObjectID id) const;
 
-    bool isAnonymous() const override { return name_.empty(); }
+    bool isUnnamed() const override { return name_.empty(); }
 
     bool isBlackBox() const;
     bool isPrimitive() const;

--- a/src/nl/nl/pnl/PNLScalarNet.cpp
+++ b/src/nl/nl/pnl/PNLScalarNet.cpp
@@ -129,11 +129,11 @@ std::string PNLScalarNet::getString() const {
 std::string PNLScalarNet::getDescription() const {
   std::ostringstream stream;
   stream << "<" << std::string(getTypeName());
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     stream << " " + getName().getString();
   }
   stream << " " << getID();
-  if (not getDesign()->isAnonymous()) {
+  if (not getDesign()->isUnnamed()) {
     stream << " " + getDesign()->getName().getString();
   }
   stream << " " << getDesign()->getID();

--- a/src/nl/nl/pnl/PNLScalarNet.h
+++ b/src/nl/nl/pnl/PNLScalarNet.h
@@ -40,8 +40,8 @@ class PNLScalarNet final: public PNLBitNet {
     /// \return this PNLScalarNet name.
     NLName getName() const override { return name_; }
     void setName(const NLName& name) override;
-    /// \return true if this PNLScalarNet is anonymous.
-    bool isAnonymous() const override { return name_.empty(); }
+    /// \return true if this PNLScalarNet is unnamed.
+    bool isUnnamed() const override { return name_.empty(); }
     NajaCollection<PNLBitNet*> getBits() const override;
 
     const char* getTypeName() const override;

--- a/src/nl/nl/pnl/PNLScalarTerm.cpp
+++ b/src/nl/nl/pnl/PNLScalarTerm.cpp
@@ -129,11 +129,11 @@ std::string PNLScalarTerm::getString() const {
 std::string PNLScalarTerm::getDescription() const {
   std::ostringstream stream;
   stream << "<" << std::string(getTypeName());
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     stream << " " + getName().getString();
   }
   stream << " " << getID();
-  if (not getDesign()->isAnonymous()) {
+  if (not getDesign()->isUnnamed()) {
     stream << " " + getDesign()->getName().getString();
   }
   stream << " " << getDesign()->getID();

--- a/src/nl/nl/pnl/PNLScalarTerm.h
+++ b/src/nl/nl/pnl/PNLScalarTerm.h
@@ -51,7 +51,7 @@ class PNLScalarTerm final: public PNLBitTerm {
     std::string getDescription() const override;
     void debugDump(size_t indent, bool recursive=true, std::ostream& stream=std::cerr) const override;
     //bool deepCompare(const PNLTerm* other, std::string& reason) const override;
-    bool isAnonymous() const override { return name_.empty(); }
+    bool isUnnamed() const override { return name_.empty(); }
     void setDirection(const PNLTerm::Direction& direction) override;
   private:
     PNLScalarTerm(PNLDesign* design, Direction direction, const NLName& name);

--- a/src/nl/nl/serialization/capnp/SNLCapnPImplementation.cpp
+++ b/src/nl/nl/serialization/capnp/SNLCapnPImplementation.cpp
@@ -60,7 +60,7 @@ void dumpInstance(
   DBImplementation::LibraryImplementation::SNLDesignImplementation::Instance::Builder& instance,
   const SNLInstance* snlInstance) {
   instance.setId(snlInstance->getID());
-  if (not snlInstance->isAnonymous()) {
+  if (not snlInstance->isUnnamed()) {
     instance.setName(snlInstance->getName().getString());
   }
   auto model = snlInstance->getModel();
@@ -114,7 +114,7 @@ void dumpScalarNet(
   const SNLScalarNet* scalarNet) {
   auto scalarNetBuilder = net.initScalarNet();
   scalarNetBuilder.setId(scalarNet->getID());
-  if (not scalarNet->isAnonymous()) {
+  if (not scalarNet->isUnnamed()) {
     scalarNetBuilder.setName(scalarNet->getName().getString());
   }
   scalarNetBuilder.setType(SNLtoCapnPNetType(scalarNet->getType()));
@@ -156,7 +156,7 @@ void dumpBusNet(
   const SNLBusNet* busNet) {
   auto busNetBuilder = net.initBusNet();
   busNetBuilder.setId(busNet->getID());
-  if (not busNet->isAnonymous()) {
+  if (not busNet->isUnnamed()) {
     busNetBuilder.setName(busNet->getName().getString());
   }
   busNetBuilder.setMsb(busNet->getMSB());

--- a/src/nl/nl/serialization/capnp/SNLCapnPInterface.cpp
+++ b/src/nl/nl/serialization/capnp/SNLCapnPInterface.cpp
@@ -96,7 +96,7 @@ void dumpScalarTerm(
   const SNLScalarTerm* scalarTerm) {
   auto scalarTermBuilder = term.initScalarTerm();
   scalarTermBuilder.setId(scalarTerm->getID());
-  if (not scalarTerm->isAnonymous()) {
+  if (not scalarTerm->isUnnamed()) {
     scalarTermBuilder.setName(scalarTerm->getName().getString());
   }
   scalarTermBuilder.setDirection(SNLtoCapnPDirection(scalarTerm->getDirection()));
@@ -107,7 +107,7 @@ void dumpBusTerm(
   const SNLBusTerm* busTerm) {
   auto busTermBuilder = term.initBusTerm();
   busTermBuilder.setId(busTerm->getID());
-  if (not busTerm->isAnonymous()) {
+  if (not busTerm->isUnnamed()) {
     busTermBuilder.setName(busTerm->getName().getString());
   }
   busTermBuilder.setMsb(busTerm->getMSB());
@@ -141,7 +141,7 @@ void dumpDesignInterface(
   SNLDesignInterface::Builder& designInterface,
   const SNLDesign* snlDesign) {
   designInterface.setId(snlDesign->getID());
-  if (not snlDesign->isAnonymous()) {
+  if (not snlDesign->isUnnamed()) {
     designInterface.setName(snlDesign->getName().getString());
   }
   designInterface.setType(SNLtoCapNpDesignType(snlDesign->getType()));
@@ -203,7 +203,7 @@ void dumpLibraryInterface(
   };
   dumpProperties(libraryInterface, snlLibrary, lambda);
 
-  if (not snlLibrary->isAnonymous()) {
+  if (not snlLibrary->isUnnamed()) {
     libraryInterface.setName(snlLibrary->getName().getString());
   }
   libraryInterface.setType(SNLtoCapnPLibraryType(snlLibrary->getType()));

--- a/src/nl/nl/snl/SNLBusNet.h
+++ b/src/nl/nl/snl/SNLBusNet.h
@@ -65,7 +65,7 @@ class SNLBusNet final: public SNLNet {
     NLID getNLID() const override;
     NLName getName() const override { return name_; }
     void setName(const NLName& name) override;
-    bool isAnonymous() const override { return name_.empty(); }
+    bool isUnnamed() const override { return name_.empty(); }
 
     void insertBits(
         std::vector<SNLBitNet*>& bits,

--- a/src/nl/nl/snl/SNLBusNetBit.cpp
+++ b/src/nl/nl/snl/SNLBusNetBit.cpp
@@ -118,8 +118,8 @@ void SNLBusNetBit::debugDump(size_t indent, bool recursive, std::ostream& stream
 }
 //LCOV_EXCL_STOP
 
-bool SNLBusNetBit::isAnonymous() const {
-  return getBus()->isAnonymous();
+bool SNLBusNetBit::isUnnamed() const {
+  return getBus()->isUnnamed();
 }
 
 void SNLBusNetBit::setName(const NLName& name) {

--- a/src/nl/nl/snl/SNLBusNetBit.h
+++ b/src/nl/nl/snl/SNLBusNetBit.h
@@ -27,7 +27,7 @@ class SNLBusNetBit final: public SNLBitNet {
 
     const char* getTypeName() const override;
     NLName getName() const override;
-    bool isAnonymous() const override;
+    bool isUnnamed() const override;
     void setName(const NLName& name) override;
     std::string getString() const override;
     std::string getDescription() const override;

--- a/src/nl/nl/snl/SNLBusTerm.h
+++ b/src/nl/nl/snl/SNLBusTerm.h
@@ -73,7 +73,7 @@ class SNLBusTerm final: public SNLTerm {
     NLID getNLID() const override;
     size_t getFlatID() const override { return flatID_; }
     NLName getName() const override { return name_; }
-    bool isAnonymous() const override { return name_.empty(); }
+    bool isUnnamed() const override { return name_.empty(); }
     void setName(const NLName& name) override;
    
     SNLTerm::Direction getDirection() const override { return direction_; }

--- a/src/nl/nl/snl/SNLBusTermBit.cpp
+++ b/src/nl/nl/snl/SNLBusTermBit.cpp
@@ -96,7 +96,7 @@ std::string SNLBusTermBit::getString() const {
 std::string SNLBusTermBit::getDescription() const {
   std::ostringstream stream;
   stream << "<" << std::string(getTypeName()) << " ";
-  if (not getBus()->isAnonymous()) {
+  if (not getBus()->isUnnamed()) {
     stream << getBus()->getName().getString();
   } else {
     stream << "(" << getBus()->getID() << ")";
@@ -113,8 +113,8 @@ void SNLBusTermBit::debugDump(size_t indent, bool recursive, std::ostream& strea
 }
 //LCOV_EXCL_STOP
 
-bool SNLBusTermBit::isAnonymous() const {
-  return getBus()->isAnonymous();
+bool SNLBusTermBit::isUnnamed() const {
+  return getBus()->isUnnamed();
 }
 
 void SNLBusTermBit::setName(const NLName& name) {

--- a/src/nl/nl/snl/SNLBusTermBit.h
+++ b/src/nl/nl/snl/SNLBusTermBit.h
@@ -30,7 +30,7 @@ class SNLBusTermBit final: public SNLBitTerm {
 
     const char* getTypeName() const override;
     NLName getName() const override;
-    bool isAnonymous() const override;
+    bool isUnnamed() const override;
     void setName(const NLName& name) override;
     SNLTerm::Direction getDirection() const override;
     std::string getString() const override;

--- a/src/nl/nl/snl/SNLDesign.cpp
+++ b/src/nl/nl/snl/SNLDesign.cpp
@@ -673,10 +673,10 @@ const char* SNLDesign::getTypeName() const {
 
 //LCOV_EXCL_START
 std::string SNLDesign::getString() const {
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     return getName().getString();
   } else {
-    return "<anonymous>";
+    return "<unnamed>";
   }
 }
 //LCOV_EXCL_STOP
@@ -685,14 +685,14 @@ std::string SNLDesign::getString() const {
 std::string SNLDesign::getDescription() const {
   std::ostringstream stream;
   stream << "<" + std::string(getTypeName());
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     stream << " " + getName().getString();
   }
   stream << " " << getID();
   if (isPrimitive()) {
     stream << " (prim)";
   }
-  if (not getLibrary()->isAnonymous()) {
+  if (not getLibrary()->isUnnamed()) {
     stream << " " << getLibrary()->getName().getString();
   }
   stream << " " << getLibrary()->getID();

--- a/src/nl/nl/snl/SNLDesign.h
+++ b/src/nl/nl/snl/SNLDesign.h
@@ -222,8 +222,8 @@ class SNLDesign final: public NLObject {
     
     /// \return NLName of this SNLDesign. 
     NLName getName() const { return name_; }
-    /// \return true if this SNLDesign is anonymous.
-    bool isAnonymous() const { return name_.empty(); }
+    /// \return true if this SNLDesign is unnamed.
+    bool isUnnamed() const { return name_.empty(); }
     /**
      * \brief set the NLName of this SNLDesign
      * \warning this method will throw an exception if the name is already used in the design's library.

--- a/src/nl/nl/snl/SNLDesignObject.h
+++ b/src/nl/nl/snl/SNLDesignObject.h
@@ -43,8 +43,8 @@ class SNLDesignObject: public NLObject {
 
     /// \return the owner NLDB of this SNLDesignObject.
     NLDB* getDB() const;
-    /// \return true if this SNLDesignObject is anonymous, false if not.
-    virtual bool isAnonymous() const = 0;
+    /// \return true if this SNLDesignObject is unnamed, false if not.
+    virtual bool isUnnamed() const = 0;
     /**
      * \brief set the SNLName of this SNLDesignObject
      * \warning this method will throw an exception if used on SNLBusTermBit, SNLBusNetBit or SNLInstTermBit

--- a/src/nl/nl/snl/SNLInstTerm.cpp
+++ b/src/nl/nl/snl/SNLInstTerm.cpp
@@ -68,8 +68,8 @@ SNLTerm::Direction SNLInstTerm::getDirection() const {
 
 NET_COMPONENT_SET_NET(SNLInstTerm)
 
-bool SNLInstTerm::isAnonymous() const {
-  return getBitTerm()->isAnonymous();
+bool SNLInstTerm::isUnnamed() const {
+  return getBitTerm()->isUnnamed();
 }
 
 void SNLInstTerm::setName(const NLName& name) {
@@ -96,11 +96,11 @@ std::string SNLInstTerm::getString() const {
 std::string SNLInstTerm::getDescription() const {
   std::ostringstream str;
   str << "<" << getTypeName();
-  if (not getInstance()->isAnonymous()) {
+  if (not getInstance()->isUnnamed()) {
     str << " " << getInstance()->getName().getString();
   }
   str << " " << getInstance()->getID();
-  if (not getBitTerm()->isAnonymous()) {
+  if (not getBitTerm()->isUnnamed()) {
     str << " " << getBitTerm()->getString();
   }
   str << " " << getBitTerm()->getID();

--- a/src/nl/nl/snl/SNLInstTerm.h
+++ b/src/nl/nl/snl/SNLInstTerm.h
@@ -30,7 +30,7 @@ class SNLInstTerm final: public SNLNetComponent {
     SNLBitNet* getNet() const override { return net_; }
     void setNet(SNLNet* net) override;
 
-    bool isAnonymous() const override;
+    bool isUnnamed() const override;
     void setName(const NLName& name) override;
     
     SNLTerm::Direction getDirection() const override;

--- a/src/nl/nl/snl/SNLInstance.cpp
+++ b/src/nl/nl/snl/SNLInstance.cpp
@@ -485,10 +485,10 @@ void SNLInstance::setModel(SNLDesign* model) {
   for (size_t i=0; i<currentTerms.size(); ++i) {
     auto currentTerm = currentTerms[i];
     auto newTerm = newTerms[i];
-    if (currentTerm->isAnonymous() != newTerm->isAnonymous()) {
+    if (currentTerm->isUnnamed() != newTerm->isUnnamed()) {
       throw NLException("SNLInstance::setModel error: anonymous contradiction");
     }
-    if (not currentTerm->isAnonymous() && currentTerm->getName() != newTerms[i]->getName()) {
+    if (not currentTerm->isUnnamed() && currentTerm->getName() != newTerms[i]->getName()) {
       throw NLException("SNLInstance::setModel error: different term names");
     }
     if (currentTerm->getID() != newTerm->getID()) {
@@ -576,7 +576,7 @@ const char* SNLInstance::getTypeName() const {
 
 //LCOV_EXCL_START
 std::string SNLInstance::getString() const {
-  if (isAnonymous()) {
+  if (isUnnamed()) {
     if (getModel()->isAssign()) {
       return "<assign: " + std::to_string(getID()) + ">";
     } else {
@@ -592,7 +592,7 @@ std::string SNLInstance::getString() const {
 std::string SNLInstance::getDescription() const {
   std::ostringstream description;
   description << "<" << getTypeName();
-  if (isAnonymous()) {
+  if (isUnnamed()) {
     if (getModel()->isAssign()) {
       description << "[assign]";
     } else {

--- a/src/nl/nl/snl/SNLInstance.h
+++ b/src/nl/nl/snl/SNLInstance.h
@@ -74,7 +74,7 @@ class SNLInstance final: public SNLDesignObject {
      */
     void setName(const NLName& name) override;
 
-    bool isAnonymous() const override { return name_.empty(); }
+    bool isUnnamed() const override { return name_.empty(); }
     ///\return true if this SNLInstance is a blackbox.
     bool isBlackBox() const;
     ///\return true if this SNLInstance is an auto blackbox.

--- a/src/nl/nl/snl/SNLMacros.h
+++ b/src/nl/nl/snl/SNLMacros.h
@@ -153,16 +153,16 @@ void TYPE::setName(const NLName& name) { \
 
 #define OWNER_RENAME(OWNER, TYPE, MAP) \
 void OWNER::rename(TYPE* object, const NLName& previousName) { \
-  /*if object was anonymous, and new one is not... just insert with new name */ \
+  /*if object was unnamed, and new one is not... just insert with new name */ \
   if (previousName.empty()) { \
-    if (not object->isAnonymous()) { \
+    if (not object->isUnnamed()) { \
       /* collision is already verified by object before trying insertion */ \
       MAP[object->getName()] = object->getID(); \
-    } /* else nothing to do, anonymous to anonymous */ \
+    } /* else nothing to do, unnamed to unnamed */ \
   } else { \
     auto node = MAP.extract(previousName); \
     assert(node); \
-    if (not object->isAnonymous()) { \
+    if (not object->isUnnamed()) { \
       node.key() = object->getName(); \
       MAP.insert(std::move(node)); \
     } \

--- a/src/nl/nl/snl/SNLScalarNet.cpp
+++ b/src/nl/nl/snl/SNLScalarNet.cpp
@@ -128,11 +128,11 @@ std::string SNLScalarNet::getString() const {
 std::string SNLScalarNet::getDescription() const {
   std::ostringstream stream;
   stream << "<" << std::string(getTypeName());
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     stream << " " + getName().getString();
   }
   stream << " " << getID();
-  if (not getDesign()->isAnonymous()) {
+  if (not getDesign()->isUnnamed()) {
     stream << " " + getDesign()->getName().getString();
   }
   stream << " " << getDesign()->getID();

--- a/src/nl/nl/snl/SNLScalarNet.h
+++ b/src/nl/nl/snl/SNLScalarNet.h
@@ -39,8 +39,8 @@ class SNLScalarNet final: public SNLBitNet {
 
     /// \return this SNLScalarNet name.
     NLName getName() const override { return name_; }
-    /// \return true if this SNLScalarNet is anonymous.
-    bool isAnonymous() const override { return name_.empty(); }
+    /// \return true if this SNLScalarNet is unnamed.
+    bool isUnnamed() const override { return name_.empty(); }
     void setName(const NLName& name) override;
     NajaCollection<SNLBitNet*> getBits() const override;
 

--- a/src/nl/nl/snl/SNLScalarTerm.cpp
+++ b/src/nl/nl/snl/SNLScalarTerm.cpp
@@ -123,11 +123,11 @@ std::string SNLScalarTerm::getString() const {
 std::string SNLScalarTerm::getDescription() const {
   std::ostringstream stream;
   stream << "<" << std::string(getTypeName());
-  if (not isAnonymous()) {
+  if (not isUnnamed()) {
     stream << " " + getName().getString();
   }
   stream << " " << getID();
-  if (not getDesign()->isAnonymous()) {
+  if (not getDesign()->isUnnamed()) {
     stream << " " + getDesign()->getName().getString();
   }
   stream << " " << getDesign()->getID();

--- a/src/nl/nl/snl/SNLScalarTerm.h
+++ b/src/nl/nl/snl/SNLScalarTerm.h
@@ -39,7 +39,7 @@ class SNLScalarTerm final: public SNLBitTerm {
     NLID::Bit getBit() const override { return 0; }
     size_t getFlatID() const override { return flatID_; }
     NLName getName() const override { return name_; }
-    bool isAnonymous() const override { return name_.empty(); }
+    bool isUnnamed() const override { return name_.empty(); }
 
     /// \brief Change the name of this SNLScalarTerm.
     void setName(const NLName& name) override;

--- a/src/nl/nl/snl/SNLSharedPath.cpp
+++ b/src/nl/nl/snl/SNLSharedPath.cpp
@@ -109,7 +109,7 @@ std::string SNLSharedPath::getString(char separator) {
     if (tailInstance_) {
       std::ostringstream stream;
       stream << headSharedPath_->getString(separator) << separator;
-      if (tailInstance_->isAnonymous()) {
+      if (tailInstance_->isUnnamed()) {
         stream << "<anon:" << tailInstance_->getID() << ">";
       } else {
         stream << tailInstance_->getName().getString();
@@ -118,7 +118,7 @@ std::string SNLSharedPath::getString(char separator) {
     }
   }
   if (tailInstance_) {
-    if (tailInstance_->isAnonymous()) {
+    if (tailInstance_->isUnnamed()) {
       return "<anon:" + std::to_string(tailInstance_->getID()) + ">";
     } else {
       return tailInstance_->getName().getString();

--- a/src/nl/python/naja_wrapping/PySNLDesign.cpp
+++ b/src/nl/python/naja_wrapping/PySNLDesign.cpp
@@ -406,7 +406,7 @@ GetObjectByIndex(SNLDesign, SNLTerm, TermByID)
 GetNameMethod(SNLDesign)
 DirectGetIntMethod(PySNLDesign_getID, getID, PySNLDesign, SNLDesign)
 DirectGetIntMethod(PySNLDesign_getRevisionCount, getRevisionCount, PySNLDesign, SNLDesign)
-GetBoolAttribute(SNLDesign, isAnonymous)
+GetBoolAttribute(SNLDesign, isUnnamed)
 GetBoolAttribute(SNLDesign, isBlackBox)
 GetBoolAttribute(SNLDesign, isPrimitive)
 GetBoolAttribute(SNLDesign, isLeaf)
@@ -473,8 +473,8 @@ PyMethodDef PySNLDesign_Methods[] = {
     "Returns True if this design is an inverter primitive"},  
   { "getName", (PyCFunction)PySNLDesign_getName, METH_NOARGS,
     "get SNLDesign name"},
-  { "isAnonymous", (PyCFunction)PySNLDesign_isAnonymous, METH_NOARGS,
-    "Returns True if the SNLDesign is anonymous"},
+  { "isUnnamed", (PyCFunction)PySNLDesign_isUnnamed, METH_NOARGS,
+    "Returns True if the SNLDesign is unnamed"},
   { "isBlackBox", (PyCFunction)PySNLDesign_isBlackBox, METH_NOARGS,
     "Returns True if the SNLDesign is a Blackbox"},
   { "isPrimitive", (PyCFunction)PySNLDesign_isPrimitive, METH_NOARGS,

--- a/src/nl/python/naja_wrapping/PySNLDesignObject.cpp
+++ b/src/nl/python/naja_wrapping/PySNLDesignObject.cpp
@@ -21,9 +21,13 @@ DBoDestroyAttribute(PySNLDesignObject_destroy, PySNLDesignObject)
 
 PyTypeObjectDefinitions(SNLDesignObject)
 
+GetBoolAttribute(SNLDesignObject, isUnnamed)
+
 PyMethodDef PySNLDesignObject_Methods[] = {
   {"getDesign", (PyCFunction)PySNLDesignObject_getDesign, METH_NOARGS,
     "Returns the SNLDesignObject owner design."},
+  {"isUnnamed", (PyCFunction)PySNLDesignObject_isUnnamed, METH_NOARGS,
+    "Returns whether the SNLDesignObject is unnamed."},
   {"setName", (PyCFunction)PySNLDesignObject_setName, METH_O,
     "Set the NLName of this SNLDesignObject."},
   {"destroy", (PyCFunction)PySNLDesignObject_destroy, METH_NOARGS,

--- a/test/nl/formats/verilog/benchmarks/test_gates2.v
+++ b/test/nl/formats/verilog/benchmarks/test_gates2.v
@@ -1,0 +1,8 @@
+module top (n0, n1, n2);
+    input n0, n1;
+    output n2;
+    wire w0, w1, w2, n0, n1, n2;
+    nand g0(w0, n1, n0);
+    not g1(w1, w0);
+    not g2(n2, w1);
+endmodule

--- a/test/nl/formats/verilog/frontend/CMakeLists.txt
+++ b/test/nl/formats/verilog/frontend/CMakeLists.txt
@@ -9,6 +9,7 @@ set(snl_vrl_constructor_tests
     SNLVRLConstructorTestAttributes.cpp
     SNLVRLConstructorTestGate0.cpp
     SNLVRLConstructorTestGate1.cpp
+    SNLVRLConstructorTestGate2.cpp
     SNLVRLConstructorTestAutoBlackBox0.cpp
 )
 add_executable(snlVRLConstructorTests ${snl_vrl_constructor_tests})

--- a/test/nl/formats/verilog/frontend/SNLVRLConstructorTest1.cpp
+++ b/test/nl/formats/verilog/frontend/SNLVRLConstructorTest1.cpp
@@ -110,10 +110,10 @@ TEST_F(SNLVRLConstructorTest1, test) {
   using Nets = std::vector<SNLNet*>;
   Nets nets(test->getNets().begin(), test->getNets().end());
   ASSERT_EQ(12, nets.size());
-  EXPECT_TRUE(nets[0]->isAnonymous());
-  EXPECT_TRUE(nets[1]->isAnonymous());
+  EXPECT_TRUE(nets[0]->isUnnamed());
+  EXPECT_TRUE(nets[1]->isUnnamed());
   for (size_t i=2; i<12; ++i) {
-    EXPECT_FALSE(nets[i]->isAnonymous());
+    EXPECT_FALSE(nets[i]->isUnnamed());
   }
 
   ASSERT_TRUE(dynamic_cast<SNLScalarNet*>(nets[0]));

--- a/test/nl/formats/verilog/frontend/SNLVRLConstructorTestAutoBlackBox0.cpp
+++ b/test/nl/formats/verilog/frontend/SNLVRLConstructorTestAutoBlackBox0.cpp
@@ -59,7 +59,7 @@ TEST_F(SNLVRLConstructorTestAutoBlackBox0, test) {
   ASSERT_EQ(1, instances.size());
   auto ins0 = instances[0];
   ASSERT_NE(ins0, nullptr);
-  EXPECT_FALSE(ins0->isAnonymous());
+  EXPECT_FALSE(ins0->isUnnamed());
 
   auto model = ins0->getModel();
   ASSERT_NE(model, nullptr);

--- a/test/nl/formats/verilog/frontend/SNLVRLConstructorTestGate0.cpp
+++ b/test/nl/formats/verilog/frontend/SNLVRLConstructorTestGate0.cpp
@@ -5,7 +5,6 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 using ::testing::ElementsAre;
-//using ::testing::TypedEq;
 
 #include <filesystem>
 #include <fstream>

--- a/test/nl/formats/verilog/frontend/SNLVRLConstructorTestGate1.cpp
+++ b/test/nl/formats/verilog/frontend/SNLVRLConstructorTestGate1.cpp
@@ -5,7 +5,6 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 using ::testing::ElementsAre;
-//using ::testing::TypedEq;
 
 #include <filesystem>
 #include <fstream>
@@ -75,7 +74,7 @@ TEST_F(SNLVRLConstructorTestGate1, test) {
   ASSERT_EQ(4, instances.size());
   auto ins0 = instances[0];
   ASSERT_NE(ins0, nullptr);
-  EXPECT_TRUE(ins0->isAnonymous());
+  EXPECT_TRUE(ins0->isUnnamed());
   auto nand3Model = ins0->getModel();
   EXPECT_TRUE(NLDB0::isNInputGate(nand3Model));
   auto nand3SingleTerm = NLDB0::getGateSingleTerm(nand3Model);
@@ -88,7 +87,7 @@ TEST_F(SNLVRLConstructorTestGate1, test) {
 
   auto ins1 = instances[1];
   ASSERT_NE(ins1, nullptr);
-  EXPECT_TRUE(ins1->isAnonymous());
+  EXPECT_TRUE(ins1->isUnnamed());
   auto nor5Model = ins1->getModel();
   EXPECT_TRUE(NLDB0::isNInputGate(nor5Model));
   auto nor5SingleTerm = NLDB0::getGateSingleTerm(nor5Model);
@@ -101,13 +100,13 @@ TEST_F(SNLVRLConstructorTestGate1, test) {
 
   auto ins2 = instances[2];
   ASSERT_NE(ins2, nullptr);
-  EXPECT_TRUE(ins2->isAnonymous());
+  EXPECT_TRUE(ins2->isUnnamed());
   auto xnor4Model = ins2->getModel();
   EXPECT_TRUE(NLDB0::isNInputGate(xnor4Model));
 
   auto ins3 = instances[3];
   ASSERT_NE(ins3, nullptr);
-  EXPECT_TRUE(ins3->isAnonymous());
+  EXPECT_TRUE(ins3->isUnnamed());
   auto nand3ModelBis = ins3->getModel();
   EXPECT_TRUE(NLDB0::isNInputGate(nand3ModelBis));
   EXPECT_EQ(nand3Model, nand3ModelBis); // should be the same as ins0

--- a/test/nl/formats/verilog/frontend/SNLVRLConstructorTestGate2.cpp
+++ b/test/nl/formats/verilog/frontend/SNLVRLConstructorTestGate2.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2023 The Naja authors <https://github.com/najaeda/naja/blob/main/AUTHORS>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+using ::testing::ElementsAre;
+
+#include <filesystem>
+#include <fstream>
+
+#include "NLUniverse.h"
+#include "NLException.h"
+
+#include "SNLScalarTerm.h"
+#include "SNLBusTerm.h"
+#include "SNLUtils.h"
+#include "SNLVRLConstructor.h"
+#include "SNLVRLDumper.h"
+
+using namespace naja::NL;
+
+#ifndef SNL_VRL_BENCHMARKS_PATH
+#define SNL_VRL_BENCHMARKS_PATH "Undefined"
+#endif
+
+class SNLVRLConstructorTestGate2: public ::testing::Test {
+  protected:
+    void SetUp() override {
+      NLUniverse* universe = NLUniverse::create();
+      auto db = NLDB::create(universe);
+      library_ = NLLibrary::create(db, NLName("MYLIB"));
+    }
+    void TearDown() override {
+      if (NLUniverse::get()) {
+        NLUniverse::get()->destroy();
+      }
+      library_ = nullptr;
+    }
+  protected:
+    NLLibrary*      library_;
+};
+
+TEST_F(SNLVRLConstructorTestGate2, test) {
+  auto db = NLDB::create(NLUniverse::get());
+  SNLVRLConstructor constructor(library_);
+  std::filesystem::path benchmarksPath(SNL_VRL_BENCHMARKS_PATH);
+  constructor.parse(benchmarksPath/"test_gates2.v");
+
+  ASSERT_EQ(1, library_->getSNLDesigns().size());
+  auto top = library_->getSNLDesign(NLName("top"));
+  ASSERT_NE(top, nullptr);
+  ASSERT_EQ(3, top->getTerms().size());
+  using Terms = std::vector<SNLTerm*>;
+  Terms terms(top->getTerms().begin(), top->getTerms().end());
+  EXPECT_THAT(terms,
+    ElementsAre(
+      top->getTerm(NLName("n0")),
+      top->getTerm(NLName("n1")),
+      top->getTerm(NLName("n2"))
+    )
+  );
+
+  constructor.setFirstPass(false);
+  constructor.parse(benchmarksPath/"test_gates2.v");
+  auto findTop = SNLUtils::findTop(library_);
+  EXPECT_EQ(findTop, top);
+
+  using Instances = std::vector<SNLInstance*>;
+  Instances instances(top->getInstances().begin(), top->getInstances().end());
+  ASSERT_EQ(3, instances.size());
+
+  EXPECT_THAT(instances,
+    ElementsAre(
+      top->getInstance(NLName("g0")),
+      top->getInstance(NLName("g1")),
+      top->getInstance(NLName("g2"))
+    )
+  );
+
+  auto g0 = instances[0];
+  ASSERT_NE(g0, nullptr);
+  EXPECT_FALSE(g0->isUnnamed());
+  EXPECT_EQ("g0", g0->getName().getString());
+
+  auto g0Model = g0->getModel(); // go is a nand
+  EXPECT_TRUE(NLDB0::isNInputGate(g0Model));
+  auto g0SingleTerm = NLDB0::getGateSingleTerm(g0Model);
+  EXPECT_NE(g0SingleTerm, nullptr);
+  EXPECT_EQ(SNLTerm::Direction::Output, g0SingleTerm->getDirection());
+  auto g0MultiTerm = NLDB0::getGateNTerms(g0Model);
+  EXPECT_EQ(SNLTerm::Direction::Input, g0MultiTerm->getDirection());
+  EXPECT_EQ(g0MultiTerm->getWidth(), 2);
+  EXPECT_EQ(g0MultiTerm->getBits().size(), 2);
+
+  auto g1 = instances[1];
+  ASSERT_NE(g1, nullptr);
+  EXPECT_FALSE(g1->isUnnamed());
+  EXPECT_EQ("g1", g1->getName().getString());
+  auto g1Model = g1->getModel(); // g1 is a not
+  EXPECT_TRUE(NLDB0::isNOutputGate(g1Model));
+  auto g1SingleTerm = NLDB0::getGateSingleTerm(g1Model);
+  EXPECT_NE(g1SingleTerm, nullptr);
+  EXPECT_EQ(SNLTerm::Direction::Input, g1SingleTerm->getDirection());
+  auto g1MultiTerm = NLDB0::getGateNTerms(g1Model);
+  EXPECT_EQ(SNLTerm::Direction::Output, g1MultiTerm->getDirection());
+  EXPECT_EQ(g1MultiTerm->getWidth(), 1);
+  EXPECT_EQ(g1MultiTerm->getBits().size(), 1);
+}
+
+TEST_F(SNLVRLConstructorTestGate2, testLoadAndDump) {
+  auto db = NLDB::create(NLUniverse::get());
+  SNLVRLConstructor constructor(library_);
+  std::filesystem::path benchmarksPath(SNL_VRL_BENCHMARKS_PATH);
+  constructor.parse(benchmarksPath/"test_gates2.v");
+
+  constructor.setFirstPass(false);
+  constructor.parse(benchmarksPath/"test_gates2.v");
+  auto top = SNLUtils::findTop(library_);
+  EXPECT_NE(nullptr, top);
+
+  std::filesystem::path outPath(SNL_VRL_DUMPER_TEST_PATH);
+  outPath = outPath / "test_gates2";
+  if (std::filesystem::exists(outPath)) {
+    std::filesystem::remove_all(outPath);
+  }
+  std::filesystem::create_directory(outPath);
+  SNLVRLDumper dumper;
+  dumper.setTopFileName(top->getName().getString() + ".v");
+  dumper.setSingleFile(true);
+  dumper.dumpDesign(top, outPath);
+}

--- a/test/nl/pnl/PNLDesignTest.cpp
+++ b/test/nl/pnl/PNLDesignTest.cpp
@@ -36,7 +36,7 @@ TEST_F(PNLDesignTest, testCreation0) {
   ASSERT_NE(design, nullptr);
   EXPECT_EQ(NLName("design"), design->getName());
   EXPECT_EQ(0, design->getID());
-  EXPECT_FALSE(design->isAnonymous());
+  EXPECT_FALSE(design->isUnnamed());
   EXPECT_EQ(design, library->getPNLDesign(0));
   EXPECT_EQ(design, library->getPNLDesign(NLName("design")));
   EXPECT_EQ(library, design->getLibrary());
@@ -62,7 +62,7 @@ TEST_F(PNLDesignTest, testCreation0) {
   PNLScalarTerm* term0 = PNLScalarTerm::create(design, PNLTerm::Direction::Input, NLName("term0"));
   ASSERT_NE(term0, nullptr);
   EXPECT_EQ(NLName("term0"), term0->getName());
-  ASSERT_FALSE(term0->isAnonymous());
+  ASSERT_FALSE(term0->isUnnamed());
   EXPECT_EQ(0, term0->getID());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 0, 0, 0, 0), term0->getNLID());
   EXPECT_EQ(design, term0->getDesign());
@@ -79,7 +79,7 @@ TEST_F(PNLDesignTest, testCreation0) {
   PNLScalarTerm* term1 = PNLScalarTerm::create(design, PNLTerm::Direction::Output, NLName("term1"));
   ASSERT_NE(term1, nullptr);
   EXPECT_EQ(NLName("term1"), term1->getName());
-  ASSERT_FALSE(term1->isAnonymous());
+  ASSERT_FALSE(term1->isUnnamed());
   EXPECT_EQ(1, term1->getID());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 0, 1, 0, 0), term1->getNLID());
   EXPECT_LT(term0->getNLID(), term1->getNLID());
@@ -104,7 +104,7 @@ TEST_F(PNLDesignTest, testCreation0) {
   PNLScalarTerm* term2 = PNLScalarTerm::create(design, PNLTerm::Direction::InOut);
   ASSERT_NE(term2, nullptr);
   EXPECT_TRUE(term2->getName().empty());
-  ASSERT_TRUE(term2->isAnonymous());
+  ASSERT_TRUE(term2->isUnnamed());
   EXPECT_EQ(2, term2->getID());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 0, 2, 0, 0), term2->getNLID());
   EXPECT_LT(term1->getNLID(), term2->getNLID());
@@ -181,7 +181,7 @@ TEST_F(PNLDesignTest, testCreation0) {
   EXPECT_LT(design->getNLID(), model->getNLID());
   //EXPECT_EQ(model, NLUniverse::get()->getPNLDesign(NLID::DesignReference(1, 0, 1)));
   //EXPECT_EQ(model, NLUniverse::get()->getObject(NLID(1, 0, 1)));
-  EXPECT_FALSE(model->isAnonymous());
+  EXPECT_FALSE(model->isUnnamed());
   EXPECT_EQ(model, library->getPNLDesign(1));
   EXPECT_EQ(model, library->getPNLDesign(NLName("model")));
   EXPECT_EQ(2, library->getPNLDesigns().size());
@@ -196,7 +196,7 @@ TEST_F(PNLDesignTest, testCreation0) {
   EXPECT_EQ(NLID(1, 0, 2), anon->getNLID());
   //EXPECT_EQ(anon, NLUniverse::get()->getPNLDesign(NLID::DesignReference(1, 0, 2)));
   //EXPECT_EQ(anon, NLUniverse::get()->getObject(NLID(1, 0, 2)));
-  EXPECT_TRUE(anon->isAnonymous());
+  EXPECT_TRUE(anon->isUnnamed());
   EXPECT_EQ(anon, library->getPNLDesign(2));
   EXPECT_EQ(library, anon->getLibrary());
   EXPECT_EQ(db_, anon->getDB());
@@ -218,7 +218,7 @@ TEST_F(PNLDesignTest, testCreation1) {
   PNLDesign* anon = PNLDesign::create(library);
   ASSERT_NE(anon, nullptr);
   EXPECT_EQ(0, anon->getID());
-  EXPECT_TRUE(anon->isAnonymous());
+  EXPECT_TRUE(anon->isUnnamed());
   EXPECT_EQ(anon, library->getPNLDesign(0));
   EXPECT_EQ(library, anon->getLibrary());
   EXPECT_EQ(db_, anon->getDB());

--- a/test/nl/pnl/PNLInstanceTest0.cpp
+++ b/test/nl/pnl/PNLInstanceTest0.cpp
@@ -73,8 +73,8 @@ TEST_F(PNLInstanceTest0, testInstTermRenameError) {
   EXPECT_EQ(design, ins->getInstTerm(b)->getDesign());
   // Test getDirection for inst term
   EXPECT_EQ(PNLTerm::Direction::Input, ins->getInstTerm(b)->getDirection());
-  // Test isAnno for inst term
-  EXPECT_FALSE(ins->getInstTerm(b)->isAnonymous());
+  // Test isUnnamed for inst term
+  EXPECT_FALSE(ins->getInstTerm(b)->isUnnamed());
   EXPECT_EQ(b->getBit(), 0);
   EXPECT_EQ(b->getWidth(), 1);
   EXPECT_EQ(NLID::DesignObjectReference(1, 0, 1, 1), b->getReference());
@@ -91,7 +91,7 @@ TEST_F(PNLInstanceTest0, testInstTermNullTerm) {
   PNLDesign* model = PNLDesign::create(library, NLName("model"));
   auto ins = PNLInstance::create(design, model, NLName("instance"));
   auto anonym = PNLInstance::create(design, model);
-  EXPECT_EQ(true, anonym->isAnonymous());
+  EXPECT_EQ(true, anonym->isUnnamed());
   EXPECT_THROW(ins->getInstTerm(nullptr), NLException);
 }
 

--- a/test/nl/pnl/PNLNetTest.cpp
+++ b/test/nl/pnl/PNLNetTest.cpp
@@ -57,7 +57,7 @@ TEST_F(PNLNetTest, testCreation) {
   EXPECT_EQ(1, lib->getID());
   EXPECT_EQ(NLName("Design"), design_->getName());
   EXPECT_EQ(0, design_->getID());
-  EXPECT_FALSE(design_->isAnonymous());
+  EXPECT_FALSE(design_->isUnnamed());
   EXPECT_EQ(design_, design_->getLibrary()->getPNLDesign(0));
   EXPECT_EQ(design_, design_->getLibrary()->getPNLDesign(NLName("Design")));
   EXPECT_TRUE(design_->getNets().empty());
@@ -164,7 +164,7 @@ TEST_F(PNLNetTest, testCreation) {
   // EXPECT_EQ(0, net0->getLSB());
   // EXPECT_EQ(32, net0->getWidth());
   // EXPECT_EQ(design_, net0->getDesign());
-  // EXPECT_FALSE(net0->isAnonymous());
+  // EXPECT_FALSE(net0->isUnnamed());
   // EXPECT_EQ(net0, design_->getNet(2));
   // EXPECT_EQ(net0, design_->getNet(NLName("net0")));
   // EXPECT_EQ(net0, design_->getBusNet(NLName("net0")));
@@ -244,7 +244,7 @@ TEST_F(PNLNetTest, testCreation) {
   //   EXPECT_EQ(net0->getID(), bit->getID());
   //   EXPECT_EQ(design_, bit->getDesign());
   //   EXPECT_FALSE(bit->getType().isDriving());
-  //   EXPECT_FALSE(bit->isAnonymous());
+  //   EXPECT_FALSE(bit->isUnnamed());
   //   //EXPECT_EQ(bit->getName(), bit->getBus()->getName());
   //   EXPECT_EQ(NLID(NLID::Type::NetBit, 1, 1, 0, 2, 0, bitNumber--), bit->getNLID());
   //   //EXPECT_EQ(bit, NLUniverse::get()->getBusNetBit(bit->getNLID()));
@@ -335,23 +335,23 @@ TEST_F(PNLNetTest, testRename) {
   auto net2 = PNLScalarNet::create(design_);
   EXPECT_EQ(net0, design_->getNet(NLName("net0")));
   //EXPECT_EQ(net1, design_->getNet(NLName("net1")));
-  EXPECT_FALSE(net0->isAnonymous());
+  EXPECT_FALSE(net0->isUnnamed());
   net0->setName(NLName());
-  EXPECT_TRUE(net0->isAnonymous());
+  EXPECT_TRUE(net0->isUnnamed());
   EXPECT_EQ(nullptr, design_->getNet(NLName("net0")));
   net0->setName(NLName("net0"));
-  EXPECT_FALSE(net0->isAnonymous());
+  EXPECT_FALSE(net0->isUnnamed());
   EXPECT_EQ(net0, design_->getNet(NLName("net0")));
-  EXPECT_FALSE(net0->isAnonymous());
+  EXPECT_FALSE(net0->isUnnamed());
   net0->setName(NLName("net0")); //nothing should happen...
   EXPECT_EQ(net0, design_->getNet(NLName("net0")));
   net0->setName(NLName("n1"));
-  EXPECT_FALSE(net0->isAnonymous());
+  EXPECT_FALSE(net0->isUnnamed());
   EXPECT_EQ(nullptr, design_->getNet(NLName("net0")));
   EXPECT_EQ(net0, design_->getNet(NLName("n1")));
-  EXPECT_TRUE(net2->isAnonymous());
+  EXPECT_TRUE(net2->isUnnamed());
   net2->setName(NLName("net2"));
-  EXPECT_FALSE(net2->isAnonymous());
+  EXPECT_FALSE(net2->isUnnamed());
   EXPECT_EQ(net2, design_->getNet(NLName("net2")));
   EXPECT_FALSE(net2->isVDD());
   EXPECT_EQ(net0->getWidth(), 1);

--- a/test/nl/pnl/PNLTermTest.cpp
+++ b/test/nl/pnl/PNLTermTest.cpp
@@ -265,23 +265,23 @@ TEST_F(PNLTermTest, testRename) {
   EXPECT_EQ(term2, design->getBitTerm(1, 0));
   EXPECT_EQ(term2, design->getBitTerm(1, -12));
   EXPECT_EQ(term2, design->getBitTerm(1, 100));
-  EXPECT_FALSE(term0->isAnonymous());
+  EXPECT_FALSE(term0->isUnnamed());
   term0->setName(NLName());
-  EXPECT_TRUE(term0->isAnonymous());
+  EXPECT_TRUE(term0->isUnnamed());
   EXPECT_EQ(nullptr, design->getTerm(NLName("term0")));
   term0->setName(NLName("term0"));
-  EXPECT_FALSE(term0->isAnonymous());
+  EXPECT_FALSE(term0->isUnnamed());
   EXPECT_EQ(term0, design->getTerm(NLName("term0")));
-  // EXPECT_FALSE(term1->isAnonymous());
+  // EXPECT_FALSE(term1->isUnnamed());
   // term1->setName(NLName("term1")); //nothing should happen...
   // EXPECT_EQ(term1, design->getTerm(NLName("term1")));
   // term1->setName(NLName("t1"));
-  // EXPECT_FALSE(term1->isAnonymous());
+  // EXPECT_FALSE(term1->isUnnamed());
   // EXPECT_EQ(nullptr, design->getTerm(NLName("term1")));
   // EXPECT_EQ(term1, design->getTerm(NLName("t1")));
-  EXPECT_TRUE(term2->isAnonymous());
+  EXPECT_TRUE(term2->isUnnamed());
   term2->setName(NLName("term2"));
-  EXPECT_FALSE(term2->isAnonymous());
+  EXPECT_FALSE(term2->isUnnamed());
   EXPECT_EQ(term2, design->getTerm(NLName("term2")));
   //Collision error
   EXPECT_THROW(term2->setName(NLName("term0")), NLException);

--- a/test/nl/python/naja_wrapping/test_snldesign_clone1.py
+++ b/test/nl/python/naja_wrapping/test_snldesign_clone1.py
@@ -26,7 +26,7 @@ class SNLDesignCloneTest1(unittest.TestCase):
     newDesign = self.design.clone()
     self.assertIsNotNone(newDesign)
     self.assertNotEqual(self.design, newDesign)
-    self.assertTrue(newDesign.isAnonymous())
+    self.assertTrue(newDesign.isUnnamed())
     self.assertEqual(self.design.getLibrary(), newDesign.getLibrary())
     self.assertEqual(self.design.getDB(), newDesign.getDB())
     termsSize = sum(1 for t in self.design.getTerms())
@@ -40,7 +40,7 @@ class SNLDesignCloneTest1(unittest.TestCase):
     newDesign = self.design.clone("cloned")
     self.assertIsNotNone(newDesign)
     self.assertNotEqual(self.design, newDesign)
-    self.assertFalse(newDesign.isAnonymous())
+    self.assertFalse(newDesign.isUnnamed())
     self.assertEqual("cloned", newDesign.getName())
 
   def testErrors(self):

--- a/test/nl/python/naja_wrapping/test_snldesign_clone2.py
+++ b/test/nl/python/naja_wrapping/test_snldesign_clone2.py
@@ -44,7 +44,7 @@ class SNLDesignCloneTest2(unittest.TestCase):
     newDesign = self.design.clone()
     self.assertIsNotNone(newDesign)
     self.assertNotEqual(self.design, newDesign)
-    self.assertTrue(newDesign.isAnonymous())
+    self.assertTrue(newDesign.isUnnamed())
     self.assertEqual(self.design.getLibrary(), newDesign.getLibrary())
     self.assertEqual(self.design.getDB(), newDesign.getDB())
     termsSize = sum(1 for t in self.design.getTerms())

--- a/test/nl/snl/kernel/NLLibraryTest.cpp
+++ b/test/nl/snl/kernel/NLLibraryTest.cpp
@@ -156,19 +156,19 @@ TEST_F(NLLibraryTest, test1) {
   ASSERT_TRUE(db);
   NLLibrary* root = NLLibrary::create(db, NLLibrary::Type::Primitives);
   ASSERT_TRUE(root);
-  EXPECT_TRUE(root->isAnonymous());
+  EXPECT_TRUE(root->isUnnamed());
   EXPECT_EQ(0, root->getID());
   EXPECT_EQ(nullptr, root->getParentLibrary());
   EXPECT_EQ(1, db->getPrimitiveLibraries().size());
 
   NLLibrary* primitives0 = NLLibrary::create(root, NLLibrary::Type::Primitives, NLName("Primitives0"));
-  EXPECT_FALSE(primitives0->isAnonymous());
+  EXPECT_FALSE(primitives0->isUnnamed());
   EXPECT_EQ(NLName("Primitives0"), primitives0->getName());
   EXPECT_EQ(1, primitives0->getID());
   EXPECT_EQ(2, db->getPrimitiveLibraries().size());
 
   NLLibrary* primitives1 = NLLibrary::create(root, NLLibrary::Type::Primitives);
-  EXPECT_TRUE(primitives1->isAnonymous());
+  EXPECT_TRUE(primitives1->isUnnamed());
   EXPECT_EQ(2, primitives1->getID());
   EXPECT_EQ(3, db->getPrimitiveLibraries().size());
 
@@ -200,9 +200,9 @@ TEST_F(NLLibraryTest, testDesignSearch) {
 TEST_F(NLLibraryTest, testRename) {
   NLDB* db = NLDB::create(universe_);
   NLLibrary* root = NLLibrary::create(db);
-  EXPECT_TRUE(root->isAnonymous());
+  EXPECT_TRUE(root->isUnnamed());
   root->setName(NLName("ROOT"));
-  EXPECT_FALSE(root->isAnonymous());
+  EXPECT_FALSE(root->isUnnamed());
   EXPECT_EQ("ROOT", root->getName().getString());
 }
 
@@ -223,7 +223,7 @@ TEST_F(NLLibraryTest, testErrors) {
   ASSERT_TRUE(db);
   NLLibrary* root = NLLibrary::create(db);
   ASSERT_TRUE(root);
-  EXPECT_TRUE(root->isAnonymous());
+  EXPECT_TRUE(root->isUnnamed());
   EXPECT_EQ(NLID::LibraryID(0), root->getID());
 
   NLDB* nullDB = nullptr;

--- a/test/nl/snl/kernel/SNLDesignCloneTest.cpp
+++ b/test/nl/snl/kernel/SNLDesignCloneTest.cpp
@@ -34,7 +34,7 @@ void compareTerms(const SNLDesign* design, const SNLDesign* newDesign) {
     EXPECT_EQ(term->getDirection(), found->getDirection());
     EXPECT_EQ(term->getName(), found->getName());
     EXPECT_EQ(term->getWidth(), found->getWidth());
-    if (not found->isAnonymous()) {
+    if (not found->isUnnamed()) {
       EXPECT_EQ(found, newDesign->getTerm(found->getName()));
     }
   }
@@ -69,7 +69,7 @@ void compareInstances(const SNLDesign* design, const SNLDesign* newDesign) {
     EXPECT_EQ(instance->getID(), found->getID());
     EXPECT_EQ(instance->getModel(), found->getModel());
     EXPECT_EQ(instance->getName(), found->getName());
-    if (not found->isAnonymous()) {
+    if (not found->isUnnamed()) {
       EXPECT_EQ(found, newDesign->getInstance(found->getName()));
     }
     compareInstParameters(instance, found);
@@ -238,7 +238,7 @@ class SNLDesignCloneTest: public ::testing::Test {
 TEST_F(SNLDesignCloneTest, testcloneInterface0) {
   auto newDesign = design_->cloneInterface();
   ASSERT_NE(nullptr, newDesign);
-  EXPECT_TRUE(newDesign->isAnonymous());
+  EXPECT_TRUE(newDesign->isUnnamed());
   EXPECT_EQ(design_->getLibrary(), newDesign->getLibrary());
   EXPECT_EQ(newDesign, design_->getLibrary()->getSNLDesign(newDesign->getID()));
   compareAttributes(design_, newDesign);
@@ -260,7 +260,7 @@ TEST_F(SNLDesignCloneTest, testcloneInterface0) {
 TEST_F(SNLDesignCloneTest, testCloneInterface1) {
   auto newDesign = design_->cloneInterface(NLName("newDesign"));
   ASSERT_NE(nullptr, newDesign);
-  EXPECT_FALSE(newDesign->isAnonymous());
+  EXPECT_FALSE(newDesign->isUnnamed());
   EXPECT_EQ(NLName("newDesign"), newDesign->getName());
   EXPECT_EQ(design_->getLibrary(), newDesign->getLibrary());
   EXPECT_EQ(newDesign, design_->getLibrary()->getSNLDesign(newDesign->getID()));
@@ -276,7 +276,7 @@ TEST_F(SNLDesignCloneTest, testCloneInterface2) {
   auto newLibrary = NLLibrary::create(design_->getLibrary()->getDB(), NLName("newLibrary"));
   auto newDesign = design_->cloneInterfaceToLibrary(newLibrary, NLName("newDesign"));
   ASSERT_NE(nullptr, newDesign);
-  EXPECT_FALSE(newDesign->isAnonymous());
+  EXPECT_FALSE(newDesign->isUnnamed());
   EXPECT_EQ(NLName("newDesign"), newDesign->getName());
   EXPECT_EQ(newLibrary, newDesign->getLibrary());
   EXPECT_EQ(newDesign, newLibrary->getSNLDesign(newDesign->getID()));
@@ -300,7 +300,7 @@ TEST_F(SNLDesignCloneTest, testClone0) {
 
   auto newDesign = design_->clone();
   ASSERT_NE(nullptr, newDesign);
-  EXPECT_TRUE(newDesign->isAnonymous());
+  EXPECT_TRUE(newDesign->isUnnamed());
   EXPECT_EQ(design_->getLibrary(), newDesign->getLibrary());
   EXPECT_EQ(newDesign, design_->getLibrary()->getSNLDesign(newDesign->getID()));
   compareAttributes(design_, newDesign);

--- a/test/nl/snl/kernel/SNLDesignTest.cpp
+++ b/test/nl/snl/kernel/SNLDesignTest.cpp
@@ -39,7 +39,7 @@ TEST_F(SNLDesignTest, testCreation0) {
   ASSERT_NE(design, nullptr);
   EXPECT_EQ(NLName("design"), design->getName());
   EXPECT_EQ(0, design->getID());
-  EXPECT_FALSE(design->isAnonymous());
+  EXPECT_FALSE(design->isUnnamed());
   EXPECT_EQ(design, library->getSNLDesign(0));
   EXPECT_EQ(design, library->getSNLDesign(NLName("design")));
   EXPECT_EQ(library, design->getLibrary());
@@ -67,7 +67,7 @@ TEST_F(SNLDesignTest, testCreation0) {
   SNLScalarTerm* term0 = SNLScalarTerm::create(design, SNLTerm::Direction::Input, NLName("term0"));
   ASSERT_NE(term0, nullptr);
   EXPECT_EQ(NLName("term0"), term0->getName());
-  ASSERT_FALSE(term0->isAnonymous());
+  ASSERT_FALSE(term0->isUnnamed());
   EXPECT_EQ(0, term0->getID());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 0, 0, 0, 0), term0->getNLID());
   EXPECT_EQ(design, term0->getDesign());
@@ -85,7 +85,7 @@ TEST_F(SNLDesignTest, testCreation0) {
   SNLScalarTerm* term1 = SNLScalarTerm::create(design, SNLTerm::Direction::Output, NLName("term1"));
   ASSERT_NE(term1, nullptr);
   EXPECT_EQ(NLName("term1"), term1->getName());
-  ASSERT_FALSE(term1->isAnonymous());
+  ASSERT_FALSE(term1->isUnnamed());
   EXPECT_EQ(1, term1->getID());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 0, 1, 0, 0), term1->getNLID());
   EXPECT_LT(term0->getNLID(), term1->getNLID());
@@ -111,7 +111,7 @@ TEST_F(SNLDesignTest, testCreation0) {
   SNLScalarTerm* term2 = SNLScalarTerm::create(design, SNLTerm::Direction::InOut);
   ASSERT_NE(term2, nullptr);
   EXPECT_TRUE(term2->getName().empty());
-  ASSERT_TRUE(term2->isAnonymous());
+  ASSERT_TRUE(term2->isUnnamed());
   EXPECT_EQ(2, term2->getID());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 0, 2, 0, 0), term2->getNLID());
   EXPECT_LT(term1->getNLID(), term2->getNLID());
@@ -132,7 +132,7 @@ TEST_F(SNLDesignTest, testCreation0) {
   SNLBusTerm* term3 = SNLBusTerm::create(design, SNLTerm::Direction::Input, 4, 0, NLName("term3"));
   ASSERT_NE(term3, nullptr);
   EXPECT_EQ(NLName("term3"), term3->getName());
-  ASSERT_FALSE(term3->isAnonymous());
+  ASSERT_FALSE(term3->isUnnamed());
   EXPECT_EQ(3, term3->getID());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 0, 3, 0, 0), term3->getNLID());
   EXPECT_EQ(term3, NLUniverse::get()->getTerm(NLID::DesignObjectReference(1, 0, 0, 3)));
@@ -189,7 +189,7 @@ TEST_F(SNLDesignTest, testCreation0) {
   EXPECT_LT(design->getNLID(), model->getNLID());
   EXPECT_EQ(model, NLUniverse::get()->getSNLDesign(NLID::DesignReference(1, 0, 1)));
   EXPECT_EQ(model, NLUniverse::get()->getObject(NLID(1, 0, 1)));
-  EXPECT_FALSE(model->isAnonymous());
+  EXPECT_FALSE(model->isUnnamed());
   EXPECT_EQ(model, library->getSNLDesign(1));
   EXPECT_EQ(model, library->getSNLDesign(NLName("model")));
   EXPECT_EQ(2, library->getSNLDesigns().size());
@@ -204,7 +204,7 @@ TEST_F(SNLDesignTest, testCreation0) {
   EXPECT_EQ(NLID(1, 0, 2), anon->getNLID());
   EXPECT_EQ(anon, NLUniverse::get()->getSNLDesign(NLID::DesignReference(1, 0, 2)));
   EXPECT_EQ(anon, NLUniverse::get()->getObject(NLID(1, 0, 2)));
-  EXPECT_TRUE(anon->isAnonymous());
+  EXPECT_TRUE(anon->isUnnamed());
   EXPECT_EQ(anon, library->getSNLDesign(2));
   EXPECT_EQ(library, anon->getLibrary());
   EXPECT_EQ(db_, anon->getDB());
@@ -226,7 +226,7 @@ TEST_F(SNLDesignTest, testCreation1) {
   SNLDesign* anon = SNLDesign::create(library);
   ASSERT_NE(anon, nullptr);
   EXPECT_EQ(0, anon->getID());
-  EXPECT_TRUE(anon->isAnonymous());
+  EXPECT_TRUE(anon->isUnnamed());
   EXPECT_EQ(anon, library->getSNLDesign(0));
   EXPECT_EQ(library, anon->getLibrary());
   EXPECT_EQ(db_, anon->getDB());

--- a/test/nl/snl/kernel/SNLInstanceSetModelTest.cpp
+++ b/test/nl/snl/kernel/SNLInstanceSetModelTest.cpp
@@ -177,7 +177,7 @@ TEST_F(SNLInstanceSetModelTest, testDifferentParametersSizeError) {
   EXPECT_TRUE(model_->deepCompare(newModel, reason, NLDesign::CompareType::IgnoreIDAndName));
   EXPECT_TRUE(reason.empty());
   EXPECT_EQ(std::string(), reason);
-  EXPECT_TRUE(newModel->isAnonymous());
+  EXPECT_TRUE(newModel->isUnnamed());
   ASSERT_EQ(3, newModel->getParameters().size());
   auto param0 = newModel->getParameter(NLName("param0"));
   ASSERT_NE(nullptr, param0);

--- a/test/nl/snl/kernel/SNLInstanceTest0.cpp
+++ b/test/nl/snl/kernel/SNLInstanceTest0.cpp
@@ -65,10 +65,10 @@ TEST_F(SNLInstanceTest0, testCreation) {
   EXPECT_TRUE(dynamic_cast<SNLBusTerm*>(termsVector[1]));
   EXPECT_TRUE(dynamic_cast<SNLScalarTerm*>(termsVector[2]));
   EXPECT_TRUE(dynamic_cast<SNLScalarTerm*>(termsVector[3]));
-  EXPECT_FALSE(termsVector[0]->isAnonymous());
-  EXPECT_TRUE(termsVector[1]->isAnonymous());
-  EXPECT_FALSE(termsVector[2]->isAnonymous());
-  EXPECT_FALSE(termsVector[3]->isAnonymous());
+  EXPECT_FALSE(termsVector[0]->isUnnamed());
+  EXPECT_TRUE(termsVector[1]->isUnnamed());
+  EXPECT_FALSE(termsVector[2]->isUnnamed());
+  EXPECT_FALSE(termsVector[3]->isUnnamed());
   EXPECT_EQ(NLName("i0"), termsVector[0]->getName());
   EXPECT_EQ(NLName("i1"), termsVector[2]->getName());
   EXPECT_EQ(NLName("i2"), termsVector[3]->getName());
@@ -262,7 +262,7 @@ TEST_F(SNLInstanceTest0, testCreation) {
   termsVector = TermsVector(termsBegin, termsEnd);
   EXPECT_EQ(5, termsVector.size());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 1, 4, 0, 0), termsVector[4]->getNLID());
-  EXPECT_FALSE(termsVector[4]->isAnonymous());
+  EXPECT_FALSE(termsVector[4]->isUnnamed());
   EXPECT_EQ(8, instance1->getInstTerms().size());
   EXPECT_EQ(8, instance2->getInstTerms().size());
   EXPECT_EQ(0, instance1->getConnectedInstTerms().size());
@@ -275,7 +275,7 @@ TEST_F(SNLInstanceTest0, testCreation) {
   termsVector = TermsVector(model->getTerms().begin(), model->getTerms().end());
   EXPECT_EQ(6, termsVector.size());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 1, 5, 0, 0), termsVector[5]->getNLID());
-  EXPECT_FALSE(termsVector[5]->isAnonymous());
+  EXPECT_FALSE(termsVector[5]->isUnnamed());
   EXPECT_EQ(14, instance1->getInstTerms().size());
   EXPECT_EQ(14, instance2->getInstTerms().size());
   EXPECT_EQ(0, instance1->getConnectedInstTerms().size());
@@ -306,20 +306,20 @@ TEST_F(SNLInstanceTest0, testCreation) {
     EXPECT_EQ(dynamic_cast<SNLBusTerm*>(termsVector[5])->getBit(2), instTermsVector[12]->getBitTerm());
     EXPECT_EQ(dynamic_cast<SNLBusTerm*>(termsVector[5])->getBit(3), instTermsVector[13]->getBitTerm());
 
-    EXPECT_FALSE(instTermsVector[0]->isAnonymous());
-    EXPECT_TRUE(instTermsVector[1]->isAnonymous());
-    EXPECT_TRUE(instTermsVector[2]->isAnonymous());
-    EXPECT_TRUE(instTermsVector[3]->isAnonymous());
-    EXPECT_TRUE(instTermsVector[4]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[5]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[6]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[7]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[8]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[9]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[10]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[11]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[12]->isAnonymous());
-    EXPECT_FALSE(instTermsVector[13]->isAnonymous());
+    EXPECT_FALSE(instTermsVector[0]->isUnnamed());
+    EXPECT_TRUE(instTermsVector[1]->isUnnamed());
+    EXPECT_TRUE(instTermsVector[2]->isUnnamed());
+    EXPECT_TRUE(instTermsVector[3]->isUnnamed());
+    EXPECT_TRUE(instTermsVector[4]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[5]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[6]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[7]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[8]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[9]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[10]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[11]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[12]->isUnnamed());
+    EXPECT_FALSE(instTermsVector[13]->isUnnamed());
 
     EXPECT_EQ(0,  termsVector[0]->getFlatID());
     EXPECT_EQ(1,  termsVector[1]->getFlatID());

--- a/test/nl/snl/kernel/SNLInstanceTest2.cpp
+++ b/test/nl/snl/kernel/SNLInstanceTest2.cpp
@@ -39,23 +39,23 @@ TEST_F(SNLInstanceTest2, testRename) {
   
   EXPECT_EQ(instance0, design_->getInstance(NLName("instance0")));
   EXPECT_EQ(instance1, design_->getInstance(NLName("instance1")));
-  EXPECT_FALSE(instance0->isAnonymous());
+  EXPECT_FALSE(instance0->isUnnamed());
   instance0->setName(NLName());
-  EXPECT_TRUE(instance0->isAnonymous());
+  EXPECT_TRUE(instance0->isUnnamed());
   EXPECT_EQ(nullptr, design_->getInstance(NLName("instance0")));
   instance0->setName(NLName("instance0"));
-  EXPECT_FALSE(instance0->isAnonymous());
+  EXPECT_FALSE(instance0->isUnnamed());
   EXPECT_EQ(instance0, design_->getInstance(NLName("instance0")));
-  EXPECT_FALSE(instance1->isAnonymous());
+  EXPECT_FALSE(instance1->isUnnamed());
   instance1->setName(NLName("instance1")); //nothing should happen...
   EXPECT_EQ(instance1, design_->getInstance(NLName("instance1")));
   instance1->setName(NLName("t1"));
-  EXPECT_FALSE(instance1->isAnonymous());
+  EXPECT_FALSE(instance1->isUnnamed());
   EXPECT_EQ(nullptr, design_->getInstance(NLName("instance1")));
   EXPECT_EQ(instance1, design_->getInstance(NLName("t1")));
-  EXPECT_TRUE(instance2->isAnonymous());
+  EXPECT_TRUE(instance2->isUnnamed());
   instance2->setName(NLName("instance2"));
-  EXPECT_FALSE(instance2->isAnonymous());
+  EXPECT_FALSE(instance2->isUnnamed());
   EXPECT_EQ(instance2, design_->getInstance(NLName("instance2")));
   //Collision error
   EXPECT_THROW(instance2->setName(NLName("instance0")), NLException);

--- a/test/nl/snl/kernel/SNLNetTest.cpp
+++ b/test/nl/snl/kernel/SNLNetTest.cpp
@@ -55,7 +55,7 @@ TEST_F(SNLNetTest, testCreation) {
   EXPECT_EQ(1, lib->getID());
   EXPECT_EQ(NLName("Design"), design_->getName());
   EXPECT_EQ(0, design_->getID());
-  EXPECT_FALSE(design_->isAnonymous());
+  EXPECT_FALSE(design_->isUnnamed());
   EXPECT_EQ(design_, design_->getLibrary()->getSNLDesign(0));
   EXPECT_EQ(design_, design_->getLibrary()->getSNLDesign(NLName("Design")));
   EXPECT_TRUE(design_->getNets().empty());
@@ -161,7 +161,7 @@ TEST_F(SNLNetTest, testCreation) {
   EXPECT_EQ(0, net0->getLSB());
   EXPECT_EQ(32, net0->getWidth());
   EXPECT_EQ(design_, net0->getDesign());
-  EXPECT_FALSE(net0->isAnonymous());
+  EXPECT_FALSE(net0->isUnnamed());
   EXPECT_EQ(net0, design_->getNet(2));
   EXPECT_EQ(net0, design_->getNet(NLName("net0")));
   EXPECT_EQ(net0, design_->getBusNet(NLName("net0")));
@@ -241,7 +241,7 @@ TEST_F(SNLNetTest, testCreation) {
     EXPECT_EQ(net0->getID(), bit->getID());
     EXPECT_EQ(design_, bit->getDesign());
     EXPECT_FALSE(bit->getType().isDriving());
-    EXPECT_FALSE(bit->isAnonymous());
+    EXPECT_FALSE(bit->isUnnamed());
     EXPECT_EQ(bit->getName(), bit->getBus()->getName());
     EXPECT_EQ(NLID(NLID::Type::NetBit, 1, 1, 0, 2, 0, bitNumber--), bit->getNLID());
     EXPECT_EQ(bit, NLUniverse::get()->getBusNetBit(bit->getNLID()));
@@ -341,23 +341,23 @@ TEST_F(SNLNetTest, testRename) {
   auto net2 = SNLScalarNet::create(design_);
   EXPECT_EQ(net0, design_->getNet(NLName("net0")));
   EXPECT_EQ(net1, design_->getNet(NLName("net1")));
-  EXPECT_FALSE(net0->isAnonymous());
+  EXPECT_FALSE(net0->isUnnamed());
   net0->setName(NLName());
-  EXPECT_TRUE(net0->isAnonymous());
+  EXPECT_TRUE(net0->isUnnamed());
   EXPECT_EQ(nullptr, design_->getNet(NLName("net0")));
   net0->setName(NLName("net0"));
-  EXPECT_FALSE(net0->isAnonymous());
+  EXPECT_FALSE(net0->isUnnamed());
   EXPECT_EQ(net0, design_->getNet(NLName("net0")));
-  EXPECT_FALSE(net1->isAnonymous());
+  EXPECT_FALSE(net1->isUnnamed());
   net1->setName(NLName("net1")); //nothing should happen...
   EXPECT_EQ(net1, design_->getNet(NLName("net1")));
   net1->setName(NLName("n1"));
-  EXPECT_FALSE(net1->isAnonymous());
+  EXPECT_FALSE(net1->isUnnamed());
   EXPECT_EQ(nullptr, design_->getNet(NLName("net1")));
   EXPECT_EQ(net1, design_->getNet(NLName("n1")));
-  EXPECT_TRUE(net2->isAnonymous());
+  EXPECT_TRUE(net2->isUnnamed());
   net2->setName(NLName("net2"));
-  EXPECT_FALSE(net2->isAnonymous());
+  EXPECT_FALSE(net2->isUnnamed());
   EXPECT_EQ(net2, design_->getNet(NLName("net2")));
   //Collision error
   EXPECT_THROW(net1->setName(NLName("net0")), NLException);

--- a/test/nl/snl/kernel/SNLTermTest.cpp
+++ b/test/nl/snl/kernel/SNLTermTest.cpp
@@ -40,7 +40,7 @@ TEST_F(SNLTermTest, testCreation) {
   SNLBusTerm* term0 = SNLBusTerm::create(design, SNLTerm::Direction::InOut, -1, -4, NLName("term0"));
   ASSERT_NE(term0, nullptr);
   EXPECT_EQ(NLName("term0"), term0->getName());
-  ASSERT_FALSE(term0->isAnonymous());
+  ASSERT_FALSE(term0->isUnnamed());
   EXPECT_EQ(0, term0->getID());
   EXPECT_EQ(NLID(NLID::Type::Term, 1, 0, 0, 0, 0, 0), term0->getNLID());
   EXPECT_EQ(NLID::DesignObjectReference(1, 0, 0, 0), term0->getReference());
@@ -56,7 +56,7 @@ TEST_F(SNLTermTest, testCreation) {
   for (auto bit: term0->getBusBits()) {
     EXPECT_EQ(SNLTerm::Direction::InOut, bit->getDirection());
     EXPECT_EQ(term0, bit->getBus());
-    EXPECT_FALSE(bit->isAnonymous());
+    EXPECT_FALSE(bit->isUnnamed());
     EXPECT_EQ(bit->getName(), bit->getBus()->getName());
   }
   EXPECT_THAT(std::vector(term0->getBits().begin(), term0->getBits().end()),
@@ -262,23 +262,23 @@ TEST_F(SNLTermTest, testRename) {
   EXPECT_EQ(term2, design->getBitTerm(2, 0));
   EXPECT_EQ(term2, design->getBitTerm(2, -12));
   EXPECT_EQ(term2, design->getBitTerm(2, 100));
-  EXPECT_FALSE(term0->isAnonymous());
+  EXPECT_FALSE(term0->isUnnamed());
   term0->setName(NLName());
-  EXPECT_TRUE(term0->isAnonymous());
+  EXPECT_TRUE(term0->isUnnamed());
   EXPECT_EQ(nullptr, design->getTerm(NLName("term0")));
   term0->setName(NLName("term0"));
-  EXPECT_FALSE(term0->isAnonymous());
+  EXPECT_FALSE(term0->isUnnamed());
   EXPECT_EQ(term0, design->getTerm(NLName("term0")));
-  EXPECT_FALSE(term1->isAnonymous());
+  EXPECT_FALSE(term1->isUnnamed());
   term1->setName(NLName("term1")); //nothing should happen...
   EXPECT_EQ(term1, design->getTerm(NLName("term1")));
   term1->setName(NLName("t1"));
-  EXPECT_FALSE(term1->isAnonymous());
+  EXPECT_FALSE(term1->isUnnamed());
   EXPECT_EQ(nullptr, design->getTerm(NLName("term1")));
   EXPECT_EQ(term1, design->getTerm(NLName("t1")));
-  EXPECT_TRUE(term2->isAnonymous());
+  EXPECT_TRUE(term2->isUnnamed());
   term2->setName(NLName("term2"));
-  EXPECT_FALSE(term2->isAnonymous());
+  EXPECT_FALSE(term2->isUnnamed());
   EXPECT_EQ(term2, design->getTerm(NLName("term2")));
   //Collision error
   EXPECT_THROW(term2->setName(NLName("term0")), NLException);

--- a/test/nl/snl/serialization/capnp/SNLCapnPTest0.cpp
+++ b/test/nl/snl/serialization/capnp/SNLCapnPTest0.cpp
@@ -238,13 +238,13 @@ TEST_F(SNLCapNpTest0, test0) {
     auto scalarNet0 = dynamic_cast<SNLScalarNet*>(nets[0]);
     EXPECT_NE(nullptr, scalarNet0);
     EXPECT_EQ(NLID::DesignObjectID(0), scalarNet0->getID());
-    EXPECT_TRUE(scalarNet0->isAnonymous());
+    EXPECT_TRUE(scalarNet0->isUnnamed());
 
     EXPECT_NE(nullptr, nets[1]);
     auto busNet1 = dynamic_cast<SNLBusNet*>(nets[1]);
     EXPECT_NE(nullptr, busNet1);
     EXPECT_EQ(NLID::DesignObjectID(1), busNet1->getID());
-    EXPECT_TRUE(busNet1->isAnonymous());
+    EXPECT_TRUE(busNet1->isUnnamed());
     EXPECT_EQ(31, busNet1->getMSB());
     EXPECT_EQ(0, busNet1->getLSB());
 
@@ -252,13 +252,13 @@ TEST_F(SNLCapNpTest0, test0) {
     auto scalarNet2 = dynamic_cast<SNLScalarNet*>(nets[2]);
     EXPECT_NE(nullptr, scalarNet2);
     EXPECT_EQ(NLID::DesignObjectID(2), scalarNet2->getID());
-    EXPECT_TRUE(scalarNet2->isAnonymous());
+    EXPECT_TRUE(scalarNet2->isUnnamed());
 
     EXPECT_NE(nullptr, nets[3]);
     auto scalarNet3 = dynamic_cast<SNLScalarNet*>(nets[3]);
     EXPECT_NE(nullptr, scalarNet3);
     EXPECT_EQ(NLID::DesignObjectID(3), scalarNet3->getID());
-    EXPECT_FALSE(scalarNet3->isAnonymous());
+    EXPECT_FALSE(scalarNet3->isUnnamed());
     EXPECT_EQ(NLName("n1"), scalarNet3->getName());
     EXPECT_EQ(2, scalarNet3->getComponents().size());
     EXPECT_TRUE(scalarNet3->getBitTerms().empty());
@@ -275,7 +275,7 @@ TEST_F(SNLCapNpTest0, test0) {
     auto busNet4 = dynamic_cast<SNLBusNet*>(nets[4]);
     EXPECT_NE(nullptr, busNet4);
     EXPECT_EQ(NLID::DesignObjectID(4), busNet4->getID());
-    EXPECT_FALSE(busNet4->isAnonymous());
+    EXPECT_FALSE(busNet4->isUnnamed());
     EXPECT_EQ(NLName("n2"), busNet4->getName());
     for (auto bit: busNet4->getBits()) {
       EXPECT_EQ(2, bit->getComponents().size());

--- a/test/nl/snl/serialization/capnp/SNLCapnPTest1.cpp
+++ b/test/nl/snl/serialization/capnp/SNLCapnPTest1.cpp
@@ -100,7 +100,7 @@ TEST_F(SNLCapNpTest1, test0) {
   EXPECT_EQ(library, lib1->getParentLibrary());
   auto lib2 = libraries[1];
   EXPECT_NE(nullptr, lib2);
-  EXPECT_TRUE(lib2->isAnonymous());
+  EXPECT_TRUE(lib2->isUnnamed());
   EXPECT_EQ(library, lib2->getParentLibrary());
   EXPECT_EQ(2, lib2->getLibraries().size());
   auto design0 = lib2->getSNLDesign(NLName("design0"));
@@ -112,11 +112,11 @@ TEST_F(SNLCapNpTest1, test0) {
   auto design1 = designs[1];
   EXPECT_TRUE(design1->isUserBlackBox());
   EXPECT_TRUE(design1->isBlackBox());
-  EXPECT_TRUE(design1->isAnonymous());
+  EXPECT_TRUE(design1->isUnnamed());
   auto design2 = designs[2];
   EXPECT_TRUE(design2->isAutoBlackBox());
   EXPECT_TRUE(design2->isBlackBox());
-  EXPECT_TRUE(design2->isAnonymous());
+  EXPECT_TRUE(design2->isUnnamed());
   EXPECT_EQ(3, design2->getTerms().size());
   EXPECT_EQ(3, design2->getScalarTerms().size());
   EXPECT_TRUE(std::all_of(
@@ -135,7 +135,7 @@ TEST_F(SNLCapNpTest1, test0) {
   EXPECT_TRUE(lib3->getLibraries().empty());
   auto lib4 = libraries[1];
   EXPECT_NE(nullptr, lib4);
-  EXPECT_TRUE(lib4->isAnonymous());
+  EXPECT_TRUE(lib4->isUnnamed());
   EXPECT_TRUE(lib4->getLibraries().empty());
 
   libraries = Libraries(db_->getLibraries().begin(), db_->getLibraries().end());
@@ -149,19 +149,19 @@ TEST_F(SNLCapNpTest1, test0) {
   EXPECT_EQ(2, libraries.size());
   auto prims1 = libraries[0];
   EXPECT_NE(nullptr, prims1);
-  EXPECT_TRUE(prims1->isAnonymous());
+  EXPECT_TRUE(prims1->isUnnamed());
   EXPECT_TRUE(prims1->isPrimitives());
   EXPECT_TRUE(prims1->getSNLDesigns().empty());
   EXPECT_EQ(1, prims1->getLibraries().size());
   auto prims2 = libraries[1];
   EXPECT_NE(nullptr, prims2);
-  EXPECT_FALSE(prims2->isAnonymous());
+  EXPECT_FALSE(prims2->isUnnamed());
   EXPECT_TRUE(prims2->isPrimitives());
   EXPECT_EQ(1, prims2->getSNLDesigns().size());
   auto prim = *(prims2->getSNLDesigns().begin());
   EXPECT_NE(nullptr, prim);
   EXPECT_TRUE(prim->isPrimitive());
-  EXPECT_FALSE(prim->isAnonymous());
+  EXPECT_FALSE(prim->isUnnamed());
   EXPECT_EQ(NLName("prim"), prim->getName());
   auto primTT = SNLDesignTruthTable::getTruthTable(prim);
   EXPECT_TRUE(primTT.isInitialized());
@@ -171,6 +171,6 @@ TEST_F(SNLCapNpTest1, test0) {
   EXPECT_EQ(1, libraries.size());
   auto prims3 = libraries[0];
   EXPECT_NE(nullptr, prims3);
-  EXPECT_FALSE(prims3->isAnonymous());
+  EXPECT_FALSE(prims3->isUnnamed());
   EXPECT_EQ(NLName("prims3"), prims3->getName());
 }


### PR DESCRIPTION
Fix bug in n-output gates: i, [o,o,o] =>[o, o ,o] , i

Refactor: Rename isAnonymous() to isUnnamed() across tests and implementations

- Updated all instances of isAnonymous() to isUnnamed() in PNLDesignTest, PNLInstanceTest0, PNLNetTest, PNLTermTest, SNLDesignCloneTest, SNLInstanceTest0, SNLNetTest, and related serialization tests.
- Adjusted assertions in unit tests to reflect the new method name, ensuring consistency in naming conventions.
- Ensured that all related comments and expected outcomes in tests were updated accordingly.