### PR TITLE
sv frontend: lower packed-array assignment patterns

### DIFF
--- a/src/nl/formats/systemverilog/frontend/SNLSVConstructor.cpp
+++ b/src/nl/formats/systemverilog/frontend/SNLSVConstructor.cpp
@@ -9934,6 +9934,68 @@ endmodule
           }
           return true;
         }
+        if (canonical.isPackedArray() && canonical.hasFixedRange()) {
+          // Packed-array assignment pattern, e.g. `logic [1:0][63:0] v = '{a, b}`.
+          // Element bit layout mirrors the unpacked case above: pattern element
+          // k corresponds to declared array index (arrayRange.left + k*step), and
+          // its bits land at translateIndex(index) * elementWidth.
+          if (pattern.elements().empty()) {
+            return std::nullopt; // LCOV_EXCL_LINE
+          }
+          const auto* elementType = canonical.getArrayElementType();
+          if (!elementType) {
+            return std::nullopt; // LCOV_EXCL_LINE
+          }
+          const auto& elementCanonical = elementType->getCanonicalType();
+          if (!elementCanonical.isIntegral()) {
+            return std::nullopt;
+          }
+          const auto rawElementWidth = elementCanonical.getBitWidth();
+          if (rawElementWidth <= 0) {
+            return std::nullopt; // LCOV_EXCL_LINE
+          }
+          const auto elementWidthBits = static_cast<size_t>(rawElementWidth);
+
+          const auto arrayRange = canonical.getFixedRange();
+          const auto arrayWidth = static_cast<size_t>(arrayRange.width());
+          if (arrayWidth != pattern.elements().size() ||
+              arrayWidth * elementWidthBits != targetWidth) {
+            return std::nullopt; // LCOV_EXCL_LINE: slang type checking rejects this shape.
+          }
+
+          bits.assign(targetWidth, nullptr);
+          int32_t index = arrayRange.left;
+          const int32_t end = arrayRange.right;
+          const int32_t step = index <= end ? 1 : -1;
+          size_t patternIndex = 0;
+          while (index != end + step) {
+            std::vector<SNLBitNet*> elementBits;
+            if (!resolveExpressionBits(
+                  design,
+                  *pattern.elements()[patternIndex],
+                  elementWidthBits,
+                  elementBits) ||
+                elementBits.size() != elementWidthBits) {
+              return std::nullopt;
+            }
+            const auto translated = arrayRange.translateIndex(index);
+            if (translated < 0 ||
+                translated >= static_cast<int32_t>(arrayWidth)) {
+              return std::nullopt; // LCOV_EXCL_LINE
+            }
+            const auto offset = static_cast<size_t>(translated) * elementWidthBits;
+            std::copy(elementBits.begin(), elementBits.end(), bits.begin() + offset);
+            index += step;
+            ++patternIndex;
+          }
+
+          if (std::any_of(bits.begin(), bits.end(), [](const SNLBitNet* bit) {
+                return bit == nullptr;
+              })) {
+            return std::nullopt; // LCOV_EXCL_LINE
+          }
+          return true;
+        }
         if (canonical.kind == SymbolKind::PackedStructType) {
           std::vector<const slang::ast::FieldSymbol*> fields;
           for (const auto& sym : canonical.as<slang::ast::PackedStructType>().members()) {

--- a/test/nl/formats/systemverilog/frontend/SNLSVConstructorTestSimple.cpp
+++ b/test/nl/formats/systemverilog/frontend/SNLSVConstructorTestSimple.cpp
@@ -34689,3 +34689,74 @@ endmodule
   ASSERT_NE(top, nullptr);
   EXPECT_NE(top->getNet(NLName("q")), nullptr);
 }
+
+TEST_F(SNLSVConstructorTestSimple, parsePackedArrayAssignmentPatternInContinuousAssign) {
+  SNLSVConstructor constructor(library_);
+  std::filesystem::path outPath(SNL_SV_DUMPER_TEST_PATH);
+  outPath = outPath / "packed_array_assignment_pattern";
+  if (std::filesystem::exists(outPath)) {
+    std::filesystem::remove_all(outPath);
+  }
+  std::filesystem::create_directory(outPath);
+
+  const auto svPath = outPath / "packed_array_assignment_pattern.sv";
+  std::ofstream svFile(svPath);
+  ASSERT_TRUE(svFile.good());
+  svFile
+    << R"(module packed_array_assignment_pattern_top(
+  input  logic [63:0]  s0,
+  input  logic [63:0]  s1,
+  output logic [127:0] o
+);
+  logic [1:0][63:0] v;
+  assign v = '{s1, s0};
+  assign o = v;
+endmodule
+)";
+  svFile.close();
+
+  constructor.construct(svPath);
+
+  auto top =
+    library_->getSNLDesign(NLName("packed_array_assignment_pattern_top"));
+  ASSERT_NE(top, nullptr);
+  EXPECT_NE(top->getNet(NLName("o")), nullptr);
+}
+
+TEST_F(SNLSVConstructorTestSimple, parseStructPatternWithPackedArrayMember) {
+  SNLSVConstructor constructor(library_);
+  std::filesystem::path outPath(SNL_SV_DUMPER_TEST_PATH);
+  outPath = outPath / "struct_pattern_with_packed_array_member";
+  if (std::filesystem::exists(outPath)) {
+    std::filesystem::remove_all(outPath);
+  }
+  std::filesystem::create_directory(outPath);
+
+  const auto svPath = outPath / "struct_pattern_with_packed_array_member.sv";
+  std::ofstream svFile(svPath);
+  ASSERT_TRUE(svFile.good());
+  svFile
+    << R"(module struct_pattern_with_packed_array_member_top(
+  input  logic [63:0]  w0,
+  input  logic [63:0]  w1,
+  input  logic [4:0]   t,
+  output logic [132:0] o
+);
+  typedef struct packed {
+    logic [4:0]       tag;
+    logic [1:0][63:0] words;
+  } entry_t;
+  entry_t packed_entry;
+  assign packed_entry = '{ words: '{w1, w0}, tag: t };
+  assign o = packed_entry;
+endmodule
+)";
+  svFile.close();
+
+  constructor.construct(svPath);
+
+  auto top =
+    library_->getSNLDesign(NLName("struct_pattern_with_packed_array_member_top"));
+  ASSERT_NE(top, nullptr);
+  EXPECT_NE(top->getNet(NLName("o")), nullptr);
+}


### PR DESCRIPTION
## What

`resolveUnbasedOrStructuredPatternBits` lowered `'{...}` assignment patterns for
unpacked arrays and packed structs, but **not packed arrays** (e.g.
`logic [1:0][63:0] v = '{a, b}`). Such a pattern fell through to `nullopt`, so any
continuous-assign RHS containing one — directly, or nested inside a `'{...}`
struct pattern via a member setter — was rejected with
`Unsupported RHS in continuous assign ... StructuredAssignmentPattern`.

## Fix

Add a packed-array case that mirrors the existing unpacked-array element
placement: derive the element width from the packed element type and map each
pattern element to its bit offset via the array's fixed range
(`translateIndex(index) * elementWidth`).

## Tests

Two new gtests in `SNLSVConstructorTestSimple`, both of which previously threw
`SNLSVUnsupportedConstructError`:

- `parsePackedArrayAssignmentPatternInContinuousAssign` — bare packed array.
- `parseStructPatternWithPackedArrayMember` — packed array nested in a packed
  struct pattern.

Full `snlSVConstructorTests` suite passes (1050 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
