### PR TITLE
sv frontend: lower $countones as an adder-fold popcount

### DIFF
--- a/src/nl/formats/systemverilog/frontend/SNLSVConstructor.cpp
+++ b/src/nl/formats/systemverilog/frontend/SNLSVConstructor.cpp
@@ -13214,6 +13214,44 @@ endmodule
           return true;
         }
 
+        if (subroutineName == "$countones") {
+          // $countones(x): population count = sum of x's bits. Lower to an
+          // adder-fold over the resolved operand bits. Sum width is bit_width(N)
+          // (2^w - 1 >= N, so no overflow); addBitVectors keeps operand width
+          // and drops the carry, hence the pre-sized accumulator.
+          auto args = callExpr.arguments();
+          if (args.size() != 1 || !args[0]) {
+            return false; // LCOV_EXCL_LINE
+          }
+          auto argWidth = getIntegralExpressionBitWidth(*args[0]);
+          if (!argWidth || !*argWidth) {
+            return false; // LCOV_EXCL_LINE
+          }
+          std::vector<SNLBitNet*> argBits;
+          if (!resolveExpressionBits(design, *args[0], *argWidth, argBits) ||
+              argBits.size() != *argWidth) {
+            return false;
+          }
+          auto* const0 = static_cast<SNLBitNet*>(getConstNet(design, false));
+          size_t sumWidth = 1;
+          for (size_t t = argBits.size(), w = 0; t; t >>= 1) {
+            sumWidth = ++w;
+          }
+          std::vector<SNLBitNet*> accBits(sumWidth, const0);
+          for (auto* argBit : argBits) {
+            std::vector<SNLBitNet*> addendBits(sumWidth, const0);
+            addendBits[0] = argBit;
+            std::vector<SNLBitNet*> sumBits;
+            if (!addBitVectors(design, accBits, addendBits, sumBits, getSourceRange(*stripped))) {
+              return false; // LCOV_EXCL_LINE
+            }
+            accBits = std::move(sumBits);
+          }
+          bits = std::move(accBits);
+          resizeBitsToWidth(bits, targetWidth, const0);
+          return true;
+        }
+
         SNLBitNet* callBit = nullptr;
         if (resolveSimpleCaseInsideFunctionCallBit(
               design,

--- a/test/nl/formats/systemverilog/frontend/SNLSVConstructorTestSimple.cpp
+++ b/test/nl/formats/systemverilog/frontend/SNLSVConstructorTestSimple.cpp
@@ -14246,10 +14246,17 @@ TEST_F(
     << R"(module always_comb_structured_assignment_pattern_member_setter_expr_resolve_failure_unsupported(
   input  logic [3:0] a_i,
   input  logic [3:0] b_i,
-  output logic [7:0] out_o
+  output logic [4:0] out_o
 );
+  function automatic logic bad_cond(input logic [3:0] op_i);
+    case (op_i) inside
+      [4'bxxxx : 4'd7]: bad_cond = 1'b1;
+      default:          bad_cond = 1'b0;
+    endcase
+  endfunction
+
   typedef struct packed {
-    logic [3:0] a;
+    logic       a;
     logic [3:0] b;
   } pair_t;
 
@@ -14257,7 +14264,7 @@ TEST_F(
   assign out_o = pair_n;
 
   always_comb begin
-    pair_n = '{a: $countones(a_i), b: b_i};
+    pair_n = '{a: bad_cond(a_i), b: b_i};
   end
 endmodule
 )";
@@ -34757,6 +34764,36 @@ endmodule
 
   auto top =
     library_->getSNLDesign(NLName("struct_pattern_with_packed_array_member_top"));
+  ASSERT_NE(top, nullptr);
+  EXPECT_NE(top->getNet(NLName("o")), nullptr);
+}
+
+TEST_F(SNLSVConstructorTestSimple, parseCountOnesInContinuousAssign) {
+  SNLSVConstructor constructor(library_);
+  std::filesystem::path outPath(SNL_SV_DUMPER_TEST_PATH);
+  outPath = outPath / "countones_continuous_assign";
+  if (std::filesystem::exists(outPath)) {
+    std::filesystem::remove_all(outPath);
+  }
+  std::filesystem::create_directory(outPath);
+
+  const auto svPath = outPath / "countones_continuous_assign.sv";
+  std::ofstream svFile(svPath);
+  ASSERT_TRUE(svFile.good());
+  svFile
+    << R"(module countones_continuous_assign_top(
+  input  logic [3:0] x,
+  output logic [2:0] o
+);
+  assign o = $countones(x);
+endmodule
+)";
+  svFile.close();
+
+  constructor.construct(svPath);
+
+  auto top =
+    library_->getSNLDesign(NLName("countones_continuous_assign_top"));
   ASSERT_NE(top, nullptr);
   EXPECT_NE(top->getNet(NLName("o")), nullptr);
 }


### PR DESCRIPTION
## What

`$countones(x)` on a runtime operand is not constant-foldable, so it reached
`resolveExpressionBits` as an unresolved system `Call` and was rejected with
`Unsupported RHS in continuous assign ... Call`. It appears throughout
issue-queue / freelist style RTL (population counts of valid / request vectors),
including as an operand of relational comparisons and inside struct / sequential
assignments.

## Fix

Lower it structurally: resolve the operand's bits, then sum them with an
adder-fold over `addBitVectors` into a `bit_width(N)`-wide accumulator (so the
running sum cannot overflow), and resize to the requested target width.

## Tests

- `parseCountOnesInContinuousAssign` (new) — previously threw
  `SNLSVUnsupportedConstructError`.
- `parseAlwaysCombStructuredAssignmentPatternMemberSetterExprResolveFailureUnsupported`
  used `$countones` purely as a stand-in "unresolvable" member-setter expression;
  since it is now supported, this negative test is switched to the existing
  `bad_cond()` case-inside-with-x-range idiom so it still exercises the
  member-setter-resolve-failure path.

Full `snlSVConstructorTests` suite passes (1049 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
