### PR TITLE
Allow multiple definitions of a primitive in Liberty

### DIFF
--- a/src/nl/formats/liberty/SNLLibertyConstructor.cpp
+++ b/src/nl/formats/liberty/SNLLibertyConstructor.cpp
@@ -21,6 +21,7 @@
 #include "YosysLibertyParser.h"
 #include "YosysLibertyException.h"
 
+#include "NajaLog.h"
 #include "NajaPerf.h"
 
 #include "NLLibrary.h"
@@ -38,6 +39,8 @@
 namespace {
 
 using namespace naja::NL;
+using ConflictingCellNamePolicy =
+  SNLLibertyConstructor::Config::ConflictingCellNamePolicy;
 
 SNLTerm::Direction getSNLDirection(const std::string& direction) {
   if (direction == "input") {
@@ -752,8 +755,25 @@ void parseCell(
   NLLibrary* library,
   const Yosys::LibertyAst* top,
   Yosys::LibertyAst* cell,
-  const std::filesystem::path& sourcePath) {
+  const std::filesystem::path& sourcePath,
+  ConflictingCellNamePolicy conflictingCellNamePolicy) {
   auto cellName = cell->args[0];
+  if (library->getSNLDesign(NLName(cellName))) {
+    if (conflictingCellNamePolicy == ConflictingCellNamePolicy::FirstOne) {
+      NAJA_LOG_WARN(
+        "In SNLLibertyConstructor, cell {} from {} already exists in "
+        "library {}, ignoring this definition.",
+        cellName,
+        sourcePath.string(),
+        library->getDescription());
+      return;
+    }
+    std::ostringstream reason;
+    reason << "Liberty parser: " << sourcePath.string()
+      << ": NLLibrary " << library->getString()
+      << " contains already a SNLDesign named: " << cellName;
+    throw SNLLibertyConstructorException(reason.str());
+  }
   auto primitive = SNLDesign::create(library, SNLDesign::Type::Primitive, NLName(cellName));
   //std::cerr << "Parse cell: " << cellName << std::endl;
   FunctionParsingType type = FunctionParsingType::Combinational;
@@ -768,10 +788,11 @@ void parseCell(
 void parseCells(
   NLLibrary* library,
   const Yosys::LibertyAst* ast,
-  const std::filesystem::path& sourcePath) {
+  const std::filesystem::path& sourcePath,
+  ConflictingCellNamePolicy conflictingCellNamePolicy) {
   for (auto child: ast->children) {
     if (child->id == "cell") {
-      parseCell(library, ast, child, sourcePath);
+      parseCell(library, ast, child, sourcePath, conflictingCellNamePolicy);
     }
   }
 }
@@ -1178,9 +1199,8 @@ void SNLLibertyConstructor::construct(const Paths& paths) {
     auto libraryName = ast->args[0];
     {
       NajaPerf::Scope constructScope("Liberty build SNL primitives");
-      //find a policy for multiple libs
       library_->setName(NLName(libraryName));
-      parseCells(library_, ast, path);
+      parseCells(library_, ast, path, config_.conflictingCellNamePolicy_);
     }
   }
   NLLibraryTruthTables::construct(library_);

--- a/src/nl/formats/liberty/SNLLibertyConstructor.h
+++ b/src/nl/formats/liberty/SNLLibertyConstructor.h
@@ -14,6 +14,19 @@ class NLLibrary;
 
 class SNLLibertyConstructor {
   public:
+    struct Config {
+      enum class ConflictingCellNamePolicy {
+        Forbid,   ///< Throw if a cell with the same name already exists in the library.
+        FirstOne  ///< Keep the first definition and ignore subsequent ones (emit a warning).
+      };
+
+      ConflictingCellNamePolicy conflictingCellNamePolicy_ {
+        ConflictingCellNamePolicy::FirstOne
+      };
+    };
+
+    Config config_ {};
+
     SNLLibertyConstructor() = delete;
     SNLLibertyConstructor(const SNLLibertyConstructor&) = delete;
     SNLLibertyConstructor(NLLibrary* library);

--- a/test/nl/formats/liberty/SNLLibertyConstructorTest0.cpp
+++ b/test/nl/formats/liberty/SNLLibertyConstructorTest0.cpp
@@ -40,6 +40,87 @@ class SNLLibertyConstructorTest0: public ::testing::Test {
     NLLibrary*  library_;
 };
 
+namespace {
+
+void writeConflictingCellLiberty(
+  const std::filesystem::path& path,
+  const std::string& libraryName,
+  const std::string& duplicateInput,
+  const std::string& uniqueCellName) {
+  std::ofstream output(path, std::ios::binary);
+  output
+    << "library (" << libraryName << ") {\n"
+    << "  cell (duplicate) {\n"
+    << "    pin (" << duplicateInput << ") { direction : input; }\n"
+    << "    pin (Y) { direction : output; function : \"" << duplicateInput << "\"; }\n"
+    << "  }\n"
+    << "  cell (" << uniqueCellName << ") {\n"
+    << "    pin (A) { direction : input; }\n"
+    << "    pin (Y) { direction : output; function : \"A\"; }\n"
+    << "  }\n"
+    << "}\n";
+}
+
+}  // namespace
+
+TEST_F(SNLLibertyConstructorTest0, testConflictingCellNameFirstOneDefault) {
+  const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+  auto firstPath = std::filesystem::temp_directory_path()
+    / std::filesystem::path(
+      "naja_liberty_conflicting_cell_first_" + std::to_string(stamp) + ".lib");
+  auto secondPath = std::filesystem::temp_directory_path()
+    / std::filesystem::path(
+      "naja_liberty_conflicting_cell_second_" + std::to_string(stamp) + ".lib");
+  writeConflictingCellLiberty(firstPath, "FIRST", "A", "first_only");
+  writeConflictingCellLiberty(secondPath, "SECOND", "B", "second_only");
+
+  SNLLibertyConstructor constructor(library_);
+  EXPECT_EQ(
+    SNLLibertyConstructor::Config::ConflictingCellNamePolicy::FirstOne,
+    constructor.config_.conflictingCellNamePolicy_);
+  ASSERT_NO_THROW(
+    constructor.construct(SNLLibertyConstructor::Paths{firstPath, secondPath}));
+
+  EXPECT_EQ(3, library_->getSNLDesigns().size());
+  auto duplicate = library_->getSNLDesign(NLName("duplicate"));
+  ASSERT_NE(nullptr, duplicate);
+  EXPECT_NE(nullptr, duplicate->getScalarTerm(NLName("A")));
+  EXPECT_EQ(nullptr, duplicate->getScalarTerm(NLName("B")));
+  EXPECT_NE(nullptr, library_->getSNLDesign(NLName("first_only")));
+  EXPECT_NE(nullptr, library_->getSNLDesign(NLName("second_only")));
+
+  std::error_code ec;
+  std::filesystem::remove(firstPath, ec);
+  std::filesystem::remove(secondPath, ec);
+}
+
+TEST_F(SNLLibertyConstructorTest0, testConflictingCellNameForbid) {
+  const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+  auto firstPath = std::filesystem::temp_directory_path()
+    / std::filesystem::path(
+      "naja_liberty_forbid_conflicting_cell_first_" + std::to_string(stamp) + ".lib");
+  auto secondPath = std::filesystem::temp_directory_path()
+    / std::filesystem::path(
+      "naja_liberty_forbid_conflicting_cell_second_" + std::to_string(stamp) + ".lib");
+  writeConflictingCellLiberty(firstPath, "FIRST", "A", "first_only");
+  writeConflictingCellLiberty(secondPath, "SECOND", "B", "second_only");
+
+  SNLLibertyConstructor constructor(library_);
+  constructor.config_.conflictingCellNamePolicy_ =
+    SNLLibertyConstructor::Config::ConflictingCellNamePolicy::Forbid;
+  try {
+    constructor.construct(SNLLibertyConstructor::Paths{firstPath, secondPath});
+    FAIL() << "Expected SNLLibertyConstructorException";
+  } catch (const SNLLibertyConstructorException& e) {
+    EXPECT_NE(std::string::npos, e.getReason().find(secondPath.string()));
+    EXPECT_NE(std::string::npos, e.getReason().find("duplicate"));
+  }
+
+  std::error_code ec;
+  std::filesystem::remove(firstPath, ec);
+  std::filesystem::remove(secondPath, ec);
+}
+
 TEST_F(SNLLibertyConstructorTest0, test0) {
   SNLLibertyConstructor constructor(library_);
   std::filesystem::path testPath(


### PR DESCRIPTION
by default keep the first one